### PR TITLE
Pass tree instance to loader constructor.

### DIFF
--- a/packages/mendel-loader-server/index.js
+++ b/packages/mendel-loader-server/index.js
@@ -4,26 +4,19 @@
 
 var path = require('path');
 var Module = require('module');
-var MendelTree = require('mendel');
 
-function MendelLoader(config) {
+function MendelLoader(tree) {
     if (!(this instanceof MendelLoader)) {
-        return new MendelLoader(config);
+        return new MendelLoader(tree);
     }
 
-    config = config || {};
-    var self = this;
-
-    self._basedir = config.basedir || process.cwd();
-    self._mountdir = config.mountdir || process.cwd();
-    self._tree = new MendelTree({
-        basedir: self._basedir
-    });
+    this._tree = tree;
+    this._serveroutdir = tree.config.serveroutdir || process.cwd();
 }
 
 MendelLoader.prototype.resolver = function(context) {
     var variations = this._getVariationMap(context);
-    return new MendelResolver(variations, this._mountdir);
+    return new MendelResolver(variations, this._serveroutdir);
 }
 
 MendelLoader.prototype._getVariationMap = function(context) {
@@ -33,9 +26,9 @@ MendelLoader.prototype._getVariationMap = function(context) {
 
 module.exports = MendelLoader;
 
-function MendelResolver(variations, mountdir) {
+function MendelResolver(variations, outdir) {
     this._variations = variations;
-    this._mountdir = mountdir;
+    this._serveroutdir = outdir;
     this._resolveCache = {};
 }
 
@@ -84,7 +77,7 @@ MendelResolver.prototype.resolve = function(name) {
     if (!this._resolveCache[name]) {
         var variation = this._variations[name];
         if (variation) {
-            this._resolveCache[name] = path.resolve(path.join(this._mountdir, variation, name));
+            this._resolveCache[name] = path.resolve(path.join(this._serveroutdir, variation, name));
         }
     }
     return this._resolveCache[name];

--- a/packages/mendel-middleware/swatch.js
+++ b/packages/mendel-middleware/swatch.js
@@ -60,7 +60,7 @@ function Swatch(opts) {
 inherits(Swatch, EventEmitter);
 
 Swatch.prototype._getBuildPath = function(srcFile) {
-    var outdir = this.config.outdir;
+    var outdir = this.config.serveroutdir;
     var destFile = this.buildPathCache[srcFile];
 
     if (!destFile) {

--- a/test/mendel-loader-server.js
+++ b/test/mendel-loader-server.js
@@ -5,6 +5,7 @@ var Module = require('module');
 var browserify = require('browserify');
 var mendelify = require('../packages/mendel-browserify');
 var requirify = require('../packages/mendel-requirify');
+var Tree = require('../lib/trees.js');
 var Loader = require('../packages/mendel-loader-server');
 
 var srcDir = path.resolve(__dirname, './app-samples/1');
@@ -21,7 +22,8 @@ test('mendel-loader-server', function(t){
             path.join(srcDir, 'app/throws.js'),
         ],
         outfile: path.join(buildDir, 'app.js'),
-        basedir: srcDir
+        basedir: srcDir,
+        outdir: buildDir
     });
 
     b.plugin(mendelify);
@@ -32,12 +34,14 @@ test('mendel-loader-server', function(t){
     b.bundle(function(err) {
         if (err) {
             return t.fail(err.message || err);
-        }
+        //TODO: Remove setTimeout once mendel-browserify exposes its stream events.
         setTimeout(function() {
-            var loader = new Loader({
+            var tree = new Tree({
                 basedir: srcDir,
-                mountdir: mountDir
+                outdir: buildDir,
+                serveroutdir: 'server'
             });
+            var loader = new Loader(tree);
 
             var inputs = [{
                 variations: ['test_B'],
@@ -90,8 +94,13 @@ test('mendel-loader-server-syntax-error', function(t){
     process.chdir(srcDir);
 
     try {
+        var tree = new Tree({
+            basedir: srcDir,
+            outdir: buildDir,
+            serveroutdir: 'server'
+        });
         // test without 'new'
-        var loader = Loader();
+        var loader = Loader(tree);
         var resolver = loader.resolver({
             bundle: 'app',
             variations: ['test_B']


### PR DESCRIPTION
This PR will allow moving the loader into Trees, so the apps will only need to create a trees instance to get loader and resolver.
