### PR TITLE
Add support for different express parsers

### DIFF
--- a/packages/mendel-middleware/index.js
+++ b/packages/mendel-middleware/index.js
@@ -60,7 +60,7 @@ function MendelMiddleware(opts) {
             return next();
         }
         var bundleConfig = bundles[params.bundle];
-        var dirs = params.variations.split(',');
+        var dirs = params.variations.split(/(,|%2C)/i);
         dirs = resolveVariations(existingVariations, dirs);
 
         if (!dirs.length || !bundleConfig) {


### PR DESCRIPTION
In Full Example we use simple parser, which gives us the "comma" instead of "%2C". But we can't be opinionated, so I added splitting to "%2C" too.
