### PR TITLE
Added check to ignore non-mendelified files for `mendel-requirify`

### DIFF
--- a/packages/mendel-requirify/index.js
+++ b/packages/mendel-requirify/index.js
@@ -13,15 +13,23 @@ function requirify(b, opts) {
     function addHooks() {
         b.pipeline.get('dedupe').push(through.obj(function(row, enc, next) {
             var that = this;
-            var file = row.file || row.id;
-            var nm = file.split('/node_modules/')[1];
 
             function done() {
                 that.push(row);
                 next();
             }
 
+            if (!row.variation) {
+                // mendelify did now find a match,
+                // i.e. file is outside base or variation dirs, skipping.
+                return done();
+            }
+
+            var file = row.file || row.id;
+            var nm = file.split('/node_modules/')[1];
+
             if (nm) {
+                // ignore node_modules
                 return done();
             }
 


### PR DESCRIPTION
Ignore non-mendelified files from `mendel-requirify` server output transform.
This is the case for files that are outside `base` or `variations` dirs and are not `node_modules`.
This was causing an error because of an invalid output path.
