### PR TITLE
New linkall script

### DIFF
--- a/bin/linkall.js
+++ b/bin/linkall.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var path = require('path');
+var async = require('async');
+var exec = require('child_process').exec;
+
+var packagesdir = path.join(__dirname, '../packages');
+var linkedModules = [];
+var linkedDeps = {};
+
+fs.readdir(packagesdir, function eachDir(err, packages) {
+    var doAgain = [];
+
+    async.eachSeries(packages, function linkPackage(file, donePackage) {
+        var pkg = require(path.join(packagesdir, file, 'package.json'));
+        var depsToLink = Object.keys(pkg.dependencies||{}).filter(function(dep) {
+            if (/^mendel/.test(dep) && !linkedDeps[file+':'+dep]) {
+                return true;
+            }
+            return false;
+        });
+        var waitFor = depsToLink.filter(function(dep) {
+            return -1 == linkedModules.indexOf(dep);
+        });
+
+        if (waitFor.length) {
+            doAgain.push(file);
+            return donePackage();
+        } else if(depsToLink.length) {
+            return async.eachSeries(depsToLink, function(dep, depDone) {
+                runLink(
+                    'npm link ' + dep,
+                    path.join(packagesdir, file),
+                    function() {
+                        linkedDeps[file+':'+dep] = true;
+                        depDone();
+                    }
+                );
+            }, function() {
+                doAgain.push(file);
+                donePackage();
+            });
+        }
+
+        runLink('npm link', path.join(packagesdir, file), function() {
+            linkedModules.push(file);
+            donePackage();
+        });
+    }, function() {
+        if (doAgain.length) {
+            eachDir(null, doAgain);
+        }
+    });
+})
+
+// inspired by enpeem@2.1.0 MIT licensed
+function runLink(link, dir, cb) {
+    var npm = exec(link, {cwd: dir});
+    var stderr$npm = npm.stderr;
+    var stdout$npm = npm.stdout;
+
+    stderr$npm.pipe(process.stderr);
+    stdout$npm.on('data', function(data) {
+        process.stdout.write(data);
+    });
+    npm.on('exit', cb);
+}

--- a/linkall
+++ b/linkall
@@ -1,7 +1,0 @@
-#!/bin/bash
-npm link
-for dir in `find packages -type d -d 1`; do
-    pushd $dir > /dev/null 2>&1
-    npm link
-    popd > /dev/null 2>&1
-done

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint": "eslint .",
     "unit": "tap test/*.js",
     "unit-file": "tap",
+    "linkall": "node ./bin/linkall.js",
     "coverage": "tap test/*.js --coverage --nyc-arg=--all",
     "coverage-file": "tap --coverage --coverage-report=lcov",
     "coverage-html": "tap test/*.js --coverage --nyc-arg=--all --coverage-report=lcov",

--- a/packages/mendel-middleware/package.json
+++ b/packages/mendel-middleware/package.json
@@ -17,7 +17,10 @@
     "browserify": "^13.0.0",
     "stream-cache": "0.0.2",
     "watchify": "^3.7.0",
-    "xtend": "^4.0.1"
+    "xtend": "^4.0.1",
+    "mendel-treenherit": "*",
+    "mendel-loader-server": "*",
+    "mendel-requirify": "*"
   },
   "peerDependencies": {
     "express": "*"


### PR DESCRIPTION
With this script hopefully we can clear the dependency confusion.
- It is not bash anymore, be friendly to windows users
- It uses whatever version of npm the user has installed
- it now cross-links sub dependencies, for instance, mendel-requirefy is linked inside mendel-middleware
- no mor files on root, just `npm run linkall`

This should be helpful when cloning a fresh copy.
