### PR TITLE
This improves the example using nodemon and fixing react string mismatch

### DIFF
--- a/examples/Readme.mdown
+++ b/examples/Readme.mdown
@@ -4,13 +4,13 @@ All examples are small applications that you can go to it's root directory and r
 
 You can then run:
 
-    $ node index.js
-
+    $ npm run development
 
 To start the server in development mode. In this mode every source maps are enabled and bundle compilation is done on demand. The first time you load the application is slow, but once you save a file, the full bundle, and all the bundle combinations, should have changes propagated almost immediately.
 
 All examples also support running in production mode:
 
-    $ npm run build && NODE_ENV=production node index.js
+    $ npm run build
+    $ npm run production
 
 Notice that in production mode bundles will load super fast, even with combinations, but in order to see code changes you will need to stop the server, run the build step again and start the server again.

--- a/examples/full-example/app.js
+++ b/examples/full-example/app.js
@@ -14,17 +14,20 @@ app.set('query parser', 'simple');
 app.get('/', function(req, res) {
     var variations = (req.query.variations||'').trim()
     .split(',').filter(Boolean);
+    var serverRender = req.query.ssr !== 'false';
+    var optionalMarkup = "";
 
-    var resolver = req.mendel.resolver('main', variations);
+    if (serverRender) {
+        var resolver = req.mendel.resolver('main', variations);
+        var Main = resolver.require('main.js');
 
-    var Main = resolver.require('main.js');
+        optionalMarkup = ReactDOMServer.renderToString(Main())
+    }
 
     var html = [
         '<!DOCTYPE html>',
         '<html><head></head><body>',
-            '<div id="main">',
-                ReactDOMServer.renderToString(Main()),
-            '</div>',
+            '<div id="main">'+optionalMarkup+'</div>',
             bundle(req, 'vendor', variations),
             bundle(req, 'main', variations),
         '</body></html>'

--- a/examples/full-example/nodemon.json
+++ b/examples/full-example/nodemon.json
@@ -1,4 +1,4 @@
 {
-  "ignore": ["build/"],
-  "ext": "js json"
+  "ignore": ["build/", "isomorphic/"],
+  "watch": ["*.js","*.json", ".mendelrc"]
 }

--- a/examples/full-example/package.json
+++ b/examples/full-example/package.json
@@ -5,21 +5,24 @@
   "main": "index.js",
   "scripts": {
     "test": "eslint .",
-    "build": "mendel"
+    "build": "mendel",
+    "development": "nodemon index.js",
+    "production": "NODE_ENV=production node index.js"
   },
   "dependencies": {
     "express": "^4.13.4",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
+    "morgan": "^1.7.0",
     "mendel-production-middleware": "*"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "eslint-plugin-react": "^5.0.1",
-    "morgan": "^1.7.0",
-    "mendel-middleware":"*",
-    "mendel":"*"
+    "nodemon": "^1.9.2",
+    "mendel": "*",
+    "mendel-middleware": "*"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
I wanted the example to be more "out of the box" working as intended. Here is the fixes in this PR:
- Morgan is actually production dependency, since it is required anyway.
- Nodemon as dev-dependency
- add "development" and "production" npm targets and update documentation
- fixes react server-render missmatch and make `&ssr=false` an option to skip server side rendering

The idea of making SSR optional is to make it easier for people to try it out in different combinations. It is easier to see how faster it is over networks that are conditioned and it is easy to show the caching behavior after the first time bundle loads. It might be useful to do the same in the tests in the future, but I don't want to tie tests to examples.
