### PR TITLE
Run `mendel-requiriy` with mendel bin

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -12,6 +12,8 @@ var path = require('path');
 var async = require('async');
 
 var parseConfig = require('mendel-config');
+var mendelBrowserify = require('mendel-browserify');
+var mendelRequirify = require('mendel-requirify');
 
 var config = parseConfig();
 logObj(config);
@@ -31,7 +33,13 @@ async.each(config.bundles, function(rawBundle, doneBundle) {
     delete bundle.entries;
 
     var b = browserify(xtend(conf, bundle));
-    b.plugin(path.join(__dirname, '../packages/mendel-browserify'), bundle);
+    b.plugin(mendelBrowserify, bundle);
+
+    if (config.serveroutdir) {
+        b.plugin(mendelRequirify, {
+            outdir: config.serveroutdir
+        });
+    }
 
     [].concat(bundle.ignore).filter(Boolean)
         .forEach(function (i) {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "glob": "^7.0.3",
     "mkdirp": "^0.5.1",
     "xtend": "^4.0.1",
-    "mendel-config": "1.0.0"
+    "mendel-config": "1.0.0",
+    "mendel-browserify": "1.0.0",
+    "mendel-requirify": "1.0.0"
   },
   "devDependencies": {
     "eslint": "^2.3.0",


### PR DESCRIPTION
When running `mendel` bin, server side files should be generated if `serveroutdir` config is present.