### PR TITLE
Added swatch worker to run server side dev watch on a child process.

### DIFF
--- a/packages/mendel-development-middleware/index.js
+++ b/packages/mendel-development-middleware/index.js
@@ -12,7 +12,7 @@ var treenherit = require('mendel-treenherit');
 var parseConfig = require('mendel-config');
 var validVariations = require('mendel-config/variations');
 var resolveVariations = require('mendel-development/resolve-variations');
-var Swatch = require('./swatch');
+var swatch = require('./swatch-worker');
 var CachedStreamCollection = require('./cached-stream-collection');
 var MendelLoader = require('mendel-development-loader');
 
@@ -30,7 +30,7 @@ function MendelMiddleware(opts) {
 
     // server side watch
     if (config.watch !== false) {
-        var swatch = new Swatch(opts).watch(); // eslint-disable-line no-unused-vars
+        var watcher = swatch.fork(opts); // eslint-disable-line no-unused-vars
     }
 
     var route = config.variationsroute || '/mendel/:variations/:bundle\.js';

--- a/packages/mendel-development-middleware/swatch-worker.js
+++ b/packages/mendel-development-middleware/swatch-worker.js
@@ -1,0 +1,100 @@
+/* Copyright 2015, Yahoo Inc.
+   Copyrights licensed under the MIT License.
+   See the accompanying LICENSE file for terms. */
+
+var EventEmitter = require('events').EventEmitter;
+var fork = require('child_process').fork;
+var xtend = require('xtend');
+var Swatch = require('./swatch');
+
+if (isWorker()) {
+    start();
+}
+
+var ids = 0;
+
+function start() {
+    var watcher;
+
+    // forward swatch events to parent process
+    function notifyParent(event) {
+        watcher.on(event, function() {
+            var args = Array.prototype.slice.call(arguments);
+            process.send({event: event, args: args});
+        });
+    }
+
+    process.on('message', function(msg) {
+        switch(msg.cmd) {
+        case 'start':
+            watcher = new Swatch(msg.opts);
+
+            // events to forward
+            var events = [
+                'changed',
+                'removed',
+                'ready',
+                'error'
+            ];
+            events.forEach(notifyParent);
+
+            watcher.watch();
+            break;
+
+        case 'stop':
+            watcher.stop();
+            break;
+
+        default:
+            console.warn('Invalid command: ' + msg.cmd);
+        }
+    });
+}
+
+function isWorker() {
+    return 'MENDEL_SWATCH_WORKER_ID' in process.env;
+}
+
+module.exports.fork = function(opts) {
+    opts = opts || {};
+
+    var worker = fork(__filename, {
+        env: xtend({}, process.env, {MENDEL_SWATCH_WORKER_ID: ids++})
+    });
+
+    var workerEvents = new EventEmitter();
+
+    workerEvents.on('error', function(err) {
+        console.error(err);
+    });
+
+    // we 'forward' the changed an remove events
+    // so changes are removed from the parent process require cache
+    workerEvents.on('changed', function(changes) {
+        changes.files.forEach(function(files) {
+            Swatch.prototype.uncacheModule.call(null, files.dest);
+        });
+    });
+
+    workerEvents.on('removed', function(src, dest) {
+        // worker takes care of the actual file unlink
+        // this just clears require cache on parent process
+        Swatch.prototype.uncacheModule.call(null, dest);
+    });
+
+    worker.on('message', function(msg) {
+        var args = msg.args;
+        args.unshift(msg.event);
+        workerEvents.emit.apply(workerEvents, args);
+    });
+
+    worker.send({cmd: 'start', opts: opts});
+
+    return {
+        on: workerEvents.on.bind(workerEvents),
+        stop: function() {
+            worker.send({cmd: 'stop'});
+            worker.kill();
+        }
+    }
+}

--- a/packages/mendel-development-middleware/swatch.js
+++ b/packages/mendel-development-middleware/swatch.js
@@ -167,6 +167,11 @@ Swatch.prototype.watch = function() {
         })(dir);
     });
 
+    var sharedWatchifyCache = {
+        cache: {},
+        packageCache: {}
+    };
+
     config.bundles.forEach(function(bundle) {
         if (!bundle.entries) {
             return;
@@ -176,10 +181,7 @@ Swatch.prototype.watch = function() {
 
         variations.forEach(function(variation) {
             var variationId = variation.id;
-            var bundleConfig = xtend({}, config, bundle, {
-                cache: {},
-                packageCache: {}
-            });
+            var bundleConfig = xtend({}, config, bundle, sharedWatchifyCache);
 
             bundleConfig.entries = bundleConfig.entries.map(function(entry) {
                 return path.join(bundleConfig.basetree, entry);

--- a/packages/mendel-development-middleware/swatch.js
+++ b/packages/mendel-development-middleware/swatch.js
@@ -72,7 +72,7 @@ Swatch.prototype._getBuildPath = function(srcFile) {
     return destFile;
 }
 
-Swatch.prototype._uncacheModule = function(destFile) {
+Swatch.prototype.uncacheModule = function(destFile) {
     delete Module._cache[destFile];
 };
 
@@ -86,7 +86,7 @@ Swatch.prototype._handleDepsChange = function(bundle, variation, srcFiles) {
 
     srcFiles.forEach(function (src) {
         var dest = self._getBuildPath(src);
-        self._uncacheModule(dest);
+        self.uncacheModule(dest);
         changes.files.push({src: src, dest: dest});
     });
 
@@ -98,7 +98,7 @@ Swatch.prototype._handleFileRemoved = function(srcFile) {
     var self = this;
     var destFile = self._getBuildPath(srcFile);
 
-    self._uncacheModule(destFile);
+    self.uncacheModule(destFile);
     fs.remove(destFile, function(err) {
         if (err) {
             return self.emit('error', err, {


### PR DESCRIPTION
This adds performance improvements:
- Running all the server side watchify pipelines in a child process.
- Sharing watchify cache between bundlers cuts time in almost half.