### PR TITLE
Block incomming requests while requirify writes server side files

### DIFF
--- a/packages/mendel-core/trees.js
+++ b/packages/mendel-core/trees.js
@@ -80,9 +80,9 @@ MendelTrees.prototype._loadBundles = function() {
         } catch (error) {
             var newError = new Error();
             newError.code = error.code;
-            if (error.code === 'MODULE_NOT_FOUND') {
+            if (error.code === 'MODULE_NOT_FOUND' || error.code === 'ENOENT') {
                 newError.message = 'Could not find "' + bundle.id
-                                 + '" bundle at path '+ bundle.manifest;
+                                 + '" bundle at path '+ bundlePath;
             } else {
                 newError.message = 'Invalid bundle file at path '+ bundle.manifest;
             }

--- a/packages/mendel-development-middleware/swatch-worker.js
+++ b/packages/mendel-development-middleware/swatch-worker.js
@@ -31,10 +31,13 @@ function start() {
 
             // events to forward
             var events = [
+                'update',
                 'changed',
                 'removed',
-                'ready',
-                'error'
+                'error',
+                'watch',
+                'finish',
+                'ready'
             ];
             events.forEach(notifyParent);
 
@@ -92,6 +95,7 @@ module.exports.fork = function(opts) {
 
     return {
         on: workerEvents.on.bind(workerEvents),
+        once: workerEvents.once.bind(workerEvents),
         stop: function() {
             worker.send({cmd: 'stop'});
             worker.kill();

--- a/test/mendel-requirify.js
+++ b/test/mendel-requirify.js
@@ -29,10 +29,7 @@ function run(t, outDir, outFile, rowTransform, cb) {
     b.plugin(requirify, {
         outdir: outDir
     });
-    b.bundle(function (err) {
-        if (err) {
-            t.fail(err.message || err);
-        }
+    b.on('mendel-requirify:finish', function () {
         var src;
         try {
             src = fs.readFileSync(outFile, 'utf-8');
@@ -54,6 +51,11 @@ function run(t, outDir, outFile, rowTransform, cb) {
             t.end();
         });
     });
+    b.bundle(function (err) {
+        if (err) {
+            t.fail(err.message || err);
+        }
+    });
 }
 
 test('mendel-requirify', function (t) {
@@ -73,7 +75,6 @@ test('mendel-requirify-defaults', function (t) {
     run(t, null, outFile, function(row) {
         row.id = path.basename(row.file);
         row.variation = experiment;
-        delete row.file;
         return row;
     }, function (t) {
         rimraf(outDir, function () {

--- a/test/trees.js
+++ b/test/trees.js
@@ -23,11 +23,11 @@ test('MendelTrees initialization', function (t) {
 
     process.chdir(appPath);
 
-    if(fs.existsSync(manifestPath)) fs.unlinkSync(manifestPath);
-    t.throws(MendelTrees, /bundle at path/, 'requires manifest to exist');
-
     fs.writeFileSync(manifestPath, '{invalid json}');
-    t.throws(MendelTrees, /Invalid bundle file/, 'requires valid manifest');
+    t.throws(MendelTrees, {message: /Invalid bundle file/}, 'requires valid manifest');
+
+    if(fs.existsSync(manifestPath)) fs.unlinkSync(manifestPath);
+    t.throws(MendelTrees, {message: /Could not find/}, 'requires manifest to exist');
 
     process.chdir(__dirname);
 });


### PR DESCRIPTION
- Added `writeCache` to `mendel-requirify` for incremental changes
- Improved `swatch` events and timing
- Fixed tests

With this change the dev middleware will block requests on app start until server side files are built, and on source file changes, attempting to avoid race conditions on incoming requests while reloading.