### PR TITLE
Make sure we honor externals, excluded and ignores in all pipelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "dependencies": {
     "async": "^1.5.2",
     "browserify": "^13.0.0",
-    "glob": "^7.0.3",
     "mkdirp": "^0.5.1",
     "xtend": "^4.0.1",
     "mendel-config": "^1.0.2",

--- a/packages/mendel-development-middleware/index.js
+++ b/packages/mendel-development-middleware/index.js
@@ -11,6 +11,7 @@ var treenherit = require('mendel-treenherit');
 
 var parseConfig = require('mendel-config');
 var validVariations = require('mendel-config/variations');
+var applyExtraOptions = require('mendel-development/apply-extra-options');
 var resolveVariations = require('mendel-development/resolve-variations');
 var swatch = require('./swatch-worker');
 var CachedStreamCollection = require('./cached-stream-collection');
@@ -143,6 +144,7 @@ function getCachedWatchfy(id, bundleConfig, dirs, cb) {
     });
 
     var bundler = browserify(bundleConfig);
+    applyExtraOptions(bundler, bundleConfig);
     bundler.transform(treenherit, { dirs: dirs });
     bundler.plugin(watchify);
 

--- a/packages/mendel-development-middleware/swatch.js
+++ b/packages/mendel-development-middleware/swatch.js
@@ -15,6 +15,7 @@ var requirify = require('mendel-requirify');
 var treenherit = require('mendel-treenherit');
 var validVariations = require('mendel-config/variations');
 var variationMatches = require('mendel-development/variation-matches');
+var applyExtraOptions = require('mendel-development/apply-extra-options');
 var watch = require('watch');
 var watchify = require('watchify');
 var xtend = require('xtend');
@@ -218,6 +219,7 @@ Swatch.prototype.watch = function() {
             bundler.plugin(requirify, {
                 outdir: outdir
             });
+            applyExtraOptions(bundler, bundleConfig); // must happen after all plugins that have "proxy"
             bundler.on('update', function(srcFiles) {
                 /*
                  * When watchify emits file change, we remove it from the require cache

--- a/packages/mendel-development/apply-extra-options.js
+++ b/packages/mendel-development/apply-extra-options.js
@@ -1,0 +1,75 @@
+var path = require('path');
+var glob = require('glob');
+
+module.exports = applyExtraOptions;
+
+function applyExtraOptions(b, options) {
+
+    [].concat(options.ignore).filter(Boolean)
+        .forEach(function (i) {
+            b._pending ++;
+            glob(i, function (err, files) {
+                if (err) return b.emit('error', err);
+                if (files.length === 0) {
+                  b.ignore(i);
+                }
+                else {
+                  files.forEach(function (file) { b.ignore(file) });
+                }
+                if (--b._pending === 0) b.emit('_ready');
+            });
+        })
+    ;
+
+    [].concat(options.exclude).filter(Boolean)
+        .forEach(function (u) {
+            b.exclude(u);
+
+            b._pending ++;
+            glob(u, function (err, files) {
+                if (err) return b.emit('error', err);
+                files.forEach(function (file) { b.exclude(file) });
+                if (--b._pending === 0) b.emit('_ready');
+            });
+        })
+    ;
+
+    [].concat(options.external).filter(Boolean)
+        .forEach(function (x) {
+            var xs = splitOnColon(x);
+            if (xs.length === 2) {
+                add(xs[0], { expose: xs[1] });
+            }
+            else if (/\*/.test(x)) {
+                b.external(x);
+                b._pending ++;
+                glob(x, function (err, files) {
+                    files.forEach(function (file) {
+                        add(file, {});
+                    });
+                    if (--b._pending === 0) b.emit('_ready');
+                });
+            }
+            else add(x, {});
+
+            function add (x, opts) {
+                if (/^[\/.]/.test(x)) b.external(path.resolve(x), opts)
+                else b.external(x, opts)
+            }
+        })
+    ;
+
+}
+
+function splitOnColon (f) {
+    var pos = f.lastIndexOf(':');
+    if (pos == -1) {
+        return [f]; // No colon
+    } else {
+        if ((/[a-zA-Z]:[\\/]/.test(f)) && (pos == 1)){
+            return [f]; // Windows path and colon is part of drive name
+        } else {
+            return [f.substr(0, pos), f.substr(pos + 1)];
+        }
+    }
+}

--- a/packages/mendel-development/package.json
+++ b/packages/mendel-development/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "falafel": "^1.2.0",
     "shasum": "^1.0.2",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "glob": "^7.0.3"
   }
 }


### PR DESCRIPTION
During development, we were not preventing external bundles to be included. This means that in the example/full-example we had a main app with react, in addition to react in the vendor file. Production was never affected.

This fixes it by using the same option in all places we create bundles ourselves.

Tests will follow on a separate PR because we have no unit tests for the middleware so far.