### PR TITLE
Merge environment config overrides

### DIFF
--- a/packages/mendel-config/defaults.js
+++ b/packages/mendel-config/defaults.js
@@ -1,0 +1,17 @@
+module.exports = function() {
+    return {
+        basedir: process.cwd(),
+        outdir: 'mendel-build',
+        bundlesoutdir: '',
+        serveroutdir: '',
+        bundleName: 'bundle',
+        manifest: 'bundle.manifest.json',
+        base: 'base',
+        basetree: 'base',
+        variationsdir: '',
+        bundles: {},
+        variations: {},
+        env: {},
+        environment: 'development'
+    };
+};

--- a/packages/mendel-development-middleware/swatch.js
+++ b/packages/mendel-development-middleware/swatch.js
@@ -32,12 +32,11 @@ function Swatch(opts) {
     EventEmitter.call(self);
 
     var config = parseConfig(opts);
-    var devOpts = opts && opts.development || {};
 
     self.config = xtend(config, {
         verbose: false,
         silent: false
-    }, devOpts);
+    });
 
     var base = config.base || 'base';
 

--- a/test/config-samples/.mendelrc
+++ b/test/config-samples/.mendelrc
@@ -55,3 +55,20 @@ variations:
 # if any dir is unexisting, it is just silently ignored
 # this allows for variation ids to have different names and/or combination
 # of directories
+
+# configurations can be overriden per environment
+env:
+  test:
+    bundles:
+      main:
+        transform:
+          - testify
+      test:
+          entries:
+            - foo.js
+            - bar.js
+  staging:
+    bundles:
+      test:
+          entries:
+            - bar.js

--- a/test/config-samples/2/package.json
+++ b/test/config-samples/2/package.json
@@ -8,6 +8,11 @@
     "variations": {
       "json_A": null,
       "json_B": ["folder_B"]
+    },
+    "env": {
+      "test": {
+        "base": "testbase"
+      }
     }
   }
 }


### PR DESCRIPTION
Added the option to override configurations based on `MENDEL_ENV` or `NODE_ENV` environment variables.

Config options can be overriden with the `env` config value in `.mendelrc`, `package.json` or through the config api params. 

```yaml
base: default
basetree: src/default

bundles:
  foo:
    entries:
      - index.js

variations:
  variation_A:
  variation_B:

env:
  production:
    bundles:
       foo:
          transform:
            - uglify
```
Values are merged recursively