### PR TITLE
Pass variations with base to `mendelify` transform.

### DIFF
--- a/packages/mendel-browserify/index.js
+++ b/packages/mendel-browserify/index.js
@@ -130,7 +130,7 @@ MendelBrowserify.prototype.createManifest = function(bundle) {
     var self = this;
     var deps = bundle.pipeline.get('deps');
 
-    deps.push(mendelify(self.variations));
+    deps.push(mendelify(self.variationsWithBase));
     deps.push(through.obj(function(row, enc, next) {
         self.pushBundleManifest(row);
         this.push(row);


### PR DESCRIPTION
`mendelify` transform needs to know about base variation to fall back when no variations exist.
This is needed because `mendel-requirify` stream transform checks for `row.variation` to be present so it can write the output file.