### PR TITLE
Fix mendel plugin recursion when using programmatically

### DIFF
--- a/packages/mendel-browserify/index.js
+++ b/packages/mendel-browserify/index.js
@@ -60,6 +60,17 @@ function MendelBrowserify(baseBundle, opts) {
         var vopts = xtend(self.baseOptions);
         var browserify = baseBundle.constructor;
         var pipeline = baseBundle.pipeline.constructor;
+
+        vopts.plugin = [].concat(vopts.plugin).filter(Boolean)
+            .filter(function(plugin) {
+                if (typeof plugin === 'string') {
+                    return plugin !== 'mendel-browserify';
+                } else if(MendelBrowserify.constructor === plugin.constructor) {
+                    return false;
+                }
+                return true;
+            });
+
         var variationBundle = browserify(vopts);
 
         self.prepareBundle(variationBundle, variation);

--- a/packages/mendel-browserify/index.js
+++ b/packages/mendel-browserify/index.js
@@ -7,6 +7,7 @@ var xtend = require('xtend');
 var defined = require('defined');
 var fs = require('fs');
 var path = require('path');
+var isarray = require('isarray');
 var mkdirp = require('mkdirp');
 var through = require('through2');
 var parseConfig = require('mendel-config');
@@ -61,15 +62,7 @@ function MendelBrowserify(baseBundle, opts) {
         var browserify = baseBundle.constructor;
         var pipeline = baseBundle.pipeline.constructor;
 
-        vopts.plugin = [].concat(vopts.plugin).filter(Boolean)
-            .filter(function(plugin) {
-                if (typeof plugin === 'string') {
-                    return plugin !== 'mendel-browserify';
-                } else if(MendelBrowserify.constructor === plugin.constructor) {
-                    return false;
-                }
-                return true;
-            });
+        vopts.plugin = nonMendelPlugins(vopts.plugin);
 
         var variationBundle = browserify(vopts);
 
@@ -250,6 +243,18 @@ MendelBrowserify.prototype.listVariation = function(bundle) {
     ));
     bundle.bundle(function() {
         process.stdout.write('\n'+bundle._log.join('\n\t')+'\n');
+    });
+}
+
+function nonMendelPlugins(plugins) {
+    return [].concat(plugins).filter(Boolean).filter(function(plugin) {
+        if (isarray(plugin)) plugin = plugin[0];
+        if (typeof plugin === 'string') {
+            return plugin !== 'mendel-browserify';
+        } else if(MendelBrowserify.constructor === plugin.constructor) {
+            return false;
+        }
+        return true;
     });
 }
 

--- a/packages/mendel-browserify/package.json
+++ b/packages/mendel-browserify/package.json
@@ -19,12 +19,13 @@
   },
   "dependencies": {
     "defined": "^1.0.0",
+    "isarray": "^1.0.0",
+    "mendel-config": "^1.0.2",
+    "mendel-development": "^1.0.2",
+    "mendel-treenherit": "^1.0.2",
     "mkdirp": "^0.5.1",
     "shasum": "^1.0.2",
     "through2": "^2.0.1",
-    "xtend": "^4.0.1",
-    "mendel-config": "^1.0.2",
-    "mendel-treenherit": "^1.0.2",
-    "mendel-development": "^1.0.2"
+    "xtend": "^4.0.1"
   }
 }

--- a/test/mendel-browserify.js
+++ b/test/mendel-browserify.js
@@ -1,0 +1,51 @@
+var path = require('path');
+var mkdirp = require('mkdirp');
+var test = require('tap').test;
+var mendelPlugin = require('mendel-browserify');
+
+var appPath = path.resolve(__dirname, 'app-samples/1/');
+var appBuild = path.join(appPath, 'build');
+mkdirp.sync(appBuild);
+process.chdir(appPath);
+
+test('mendel-browserify', function (t) {
+    t.plan(2);
+    var calls;
+
+
+    function Bro(opts) {
+        calls.push(opts);
+        this._options = opts;
+        this.transform = function(){};
+        this.pipeline = {
+            get: function(){
+                return {
+                    push: function(){}
+                };
+            }
+        };
+        this.on = function(){};
+        return this;
+    }
+
+    calls = [];
+    mendelPlugin(new Bro({
+        plugin: [mendelPlugin]
+    }), {basedir: './'});
+    var callsWithPlugins = calls.filter(function(opts) {
+        return opts.plugin.length;
+    });
+    t.equal(callsWithPlugins.length, 1);
+
+    calls = [];
+
+    mendelPlugin(new Bro({
+        plugin: ['mendel-browserify', 2]
+    }), {basedir: './'});
+    callsWithPlugins = calls.filter(function(opts) {
+        return opts.plugin.length >= 2;
+    });
+    t.equal(callsWithPlugins.length, 1);
+
+    return;
+});

--- a/test/mendel-browserify.js
+++ b/test/mendel-browserify.js
@@ -9,7 +9,7 @@ mkdirp.sync(appBuild);
 process.chdir(appPath);
 
 test('mendel-browserify', function (t) {
-    t.plan(2);
+    t.plan(3);
     var calls;
 
 
@@ -41,6 +41,16 @@ test('mendel-browserify', function (t) {
 
     mendelPlugin(new Bro({
         plugin: ['mendel-browserify', 2]
+    }), {basedir: './'});
+    callsWithPlugins = calls.filter(function(opts) {
+        return opts.plugin.length >= 2;
+    });
+    t.equal(callsWithPlugins.length, 1);
+
+    calls = [];
+
+    mendelPlugin(new Bro({
+        plugin: [ ['mendel-browserify', {}], [mendelPlugin, {}]]
     }), {basedir: './'});
     callsWithPlugins = calls.filter(function(opts) {
         return opts.plugin.length >= 2;


### PR DESCRIPTION
```js
var fs = require('fs');
var babelify = require('babelify');
var browserify = require('browserify');
var mendelPlugin = require('mendel-browserify');

var b = browserify({
    entries: ['./isomorphic/base/main.js'],
    transform: [babelify],
    plugin: [mendelPlugin]
});
b.external(['react', 'react-dom']);

b.bundle().pipe(fs.createWriteStream('main.programmatic.js'))
```

The code above is valid and would go with infinite recursion. PR adds a filter on the plugin and add tests.

@tufandevrim pay attention to the `constructor` part because I think you'll need to add this to extractify