### PR TITLE
Fixing mendel manifest generation to work better with exposed modules and JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Build toolchain for experimentation on isomorphic web applications with tree-inheritance and multivariate support.",
   "keywords": [
     "testing",
@@ -57,9 +57,9 @@
     "mkdirp": "^0.5.1",
     "xtend": "^4.0.1",
     "mendel-config": "^1.0.5",
-    "mendel-browserify": "^1.0.5",
-    "mendel-development": "^1.0.5",
-    "mendel-requirify": "^1.0.5"
+    "mendel-browserify": "^1.0.6",
+    "mendel-development": "^1.0.6",
+    "mendel-requirify": "^1.0.6"
   },
   "devDependencies": {
     "eslint": "^2.3.0",

--- a/packages/mendel-browserify/index.js
+++ b/packages/mendel-browserify/index.js
@@ -131,8 +131,12 @@ MendelBrowserify.prototype.addPipelineDebug = function(bundle) {
 }
 
 MendelBrowserify.prototype.createManifest = function(bundle) {
+    // the parts that we care about pipeline are:
+    // record, deps, json, unbom, unshebang
+    // the later 3 are just small transformations we also need
+    // but semantically we are dealing with deps
+    var deps = bundle.pipeline.get('unshebang');
     var self = this;
-    var deps = bundle.pipeline.get('deps');
 
     deps.push(mendelify(self.variationsWithBase));
     deps.push(through.obj(function(row, enc, next) {

--- a/packages/mendel-browserify/package.json
+++ b/packages/mendel-browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-browserify",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Browserify plugin for creating bundle A/B test and other variations based on mendel tree merge model. Created for mendel.",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   "dependencies": {
     "defined": "^1.0.0",
     "mendel-config": "^1.0.5",
-    "mendel-development": "^1.0.5",
+    "mendel-development": "^1.0.6",
     "mendel-treenherit": "^1.0.5",
     "mkdirp": "^0.5.1",
     "shasum": "^1.0.2",

--- a/packages/mendel-development-loader/package.json
+++ b/packages/mendel-development-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development-loader",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Mendel development server side require hook.",
   "main": "loader.js",
   "scripts": {
@@ -18,7 +18,7 @@
     "url": "https://github.com/yahoo/mendel"
   },
   "dependencies": {
-    "mendel-development": "^1.0.5",
+    "mendel-development": "^1.0.6",
     "mendel-loader": "^1.0.5"
   }
 }

--- a/packages/mendel-development-middleware/package.json
+++ b/packages/mendel-development-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development-middleware",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "express middleware for meldel",
   "main": "index.js",
   "scripts": {
@@ -21,9 +21,9 @@
     "browserify": "^13.0.0",
     "fs-extra": "^0.30.0",
     "mendel-config": "^1.0.5",
-    "mendel-development": "^1.0.5",
-    "mendel-development-loader": "^1.0.5",
-    "mendel-requirify": "^1.0.5",
+    "mendel-development": "^1.0.6",
+    "mendel-development-loader": "^1.0.6",
+    "mendel-requirify": "^1.0.6",
     "mendel-treenherit": "^1.0.5",
     "stream-cache": "0.0.2",
     "watch": "^0.18.0",

--- a/packages/mendel-development/mendelify-transform-stream.js
+++ b/packages/mendel-development/mendelify-transform-stream.js
@@ -7,22 +7,27 @@ var through = require('through2');
 var variationMatches = require('./variation-matches');
 var mendelifyRequireTransform = require('./mendelify-require-transform');
 
-function mendelifyTransformStream(variations) {
+function mendelifyTransformStream(variations, expose) {
     return through.obj(function mendelify(row, enc, next) {
-        var match = variationMatches(variations, row.file);
-        if (match) {
-            row.id = match.file;
-            row.variation = match.dir;
+        if (!avoidMendelify(row.file)) {
+            var match = variationMatches(variations, row.file);
+            if (match) {
+                row.id = match.file;
+                row.variation = match.dir;
+            }
         }
 
         Object.keys(row.deps).forEach(function (key) {
-            var depMatch = variationMatches(variations, key);
-            if (depMatch) {
-                row.deps[depMatch.file] = depMatch.file;
-                delete row.deps[key];
+            if (!avoidMendelify(row.deps[key])) {
+                var depMatch = variationMatches(variations, key);
+                if (depMatch) {
+                    row.deps[depMatch.file] = depsValue(
+                        row.deps[key], variations, expose
+                    );
+                    delete row.deps[key];
+                }
             }
         });
-
 
         row.rawSource = row.source;
         row.source = mendelifyRequireTransform(row.file, row.source, variations);
@@ -31,6 +36,32 @@ function mendelifyTransformStream(variations) {
         this.push(row);
         next();
     });
+}
+
+function avoidMendelify(file) {
+    var isExternal = file === false;
+    var isNodeModule = -1 !== (file||'').indexOf("node_modules");
+
+    return isExternal || isNodeModule;
+}
+
+function depsValue(path, variations, expose) {
+    var exposedModule = exposeKey(expose, path);
+    if (exposedModule) {
+        return exposedModule;
+    }
+    return variationMatches(variations, path).file;
+}
+
+function exposeKey(expose, file) {
+    var exposedModule = false;
+    Object.keys(expose).forEach(function(key) {
+        var value = expose[key];
+        if (file === value) {
+            exposedModule = key;
+        }
+    });
+    return exposedModule;
 }
 
 module.exports = mendelifyTransformStream;

--- a/packages/mendel-development/package.json
+++ b/packages/mendel-development/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Mendel shared dependencies for build and development",
   "main": "index.js",
   "scripts": {

--- a/packages/mendel-requirify/package.json
+++ b/packages/mendel-requirify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-requirify",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Write individual mendel-requirified dep files from the mendel browserify pipeline.",
   "main": "index.js",
   "scripts": {
@@ -20,6 +20,6 @@
   "dependencies": {
     "fs-extra": "~0.26.5",
     "through2": "^2.0.1",
-    "mendel-development": "^1.0.5"
+    "mendel-development": "^1.0.6"
   }
 }


### PR DESCRIPTION
Handling of exposed modules only worked correctly if external libraries didn't depend on each other. The full example still needs to be updated to cover this case, which would happen if some other library required React on vendor library. Also, if we require a file (instead of using entries)  that is inside base folder, it would also need this patch.