### PR TITLE
[DNM] Adding getExposed method

### DIFF
--- a/examples/full-example/app.js
+++ b/examples/full-example/app.js
@@ -24,9 +24,21 @@ app.get('/', function(req, res) {
         optionalMarkup = ReactDOMServer.renderToString(Main())
     }
 
+    var exposed = req.mendel.getExposed(variations);
+    var depBundleMap = Object.keys(exposed).reduce(function(acc, bundle) {
+        exposed[bundle].deps.forEach(function(dep) {
+            acc[dep.expose] = exposed[bundle].path;
+        });
+        return acc;
+    }, {});
+
     var html = [
         '<!DOCTYPE html>',
-        '<html><head></head><body>',
+        '<html><head>',
+       '<script>window.exposedDeps=',
+        JSON.stringify(depBundleMap),
+        ';</script>',
+        '</head><body>',
             '<div id="main">'+optionalMarkup+'</div>',
             bundle(req, 'vendor', variations),
             bundle(req, 'main', variations),


### PR DESCRIPTION
@irae here is what I come up with for getting exposed dependencies.
If this is fine, I'll add same function into `mendel-development-middleware` and some tests.

Let me know what you think

### TODO:
* [x] update the example to load lazy component on demand
* [ ] update `mendel-development-middleware`
* [ ] rebase 
