### PR TITLE
Alternative draft for exposing bundles

### DIFF
--- a/examples/full-example/app.js
+++ b/examples/full-example/app.js
@@ -33,7 +33,7 @@ app.get('/', function(req, res) {
             // WARNING: This temporary "lazy" bundle is not part of the example
             // The dev team needs this here for a while in order to
             // do some work in parallel branches
-            bundle(req, 'temporary', variations),
+            entryMap(req, 'temporary', variations),
             // END WARNING
         '</body></html>'
     ].join('\n');
@@ -45,6 +45,29 @@ app.get('/', function(req, res) {
 function bundle(req, bundle, variations) {
     var url = req.mendel.getURL(bundle, variations);
     return '<script src="'+url+'"></script>';
+}
+
+function entryMap(req, bundle, variations) {
+    // req.mendel.getBundleEntries contains all bundles as keys and array of
+    // entries that were used and normalized by variations, this allows apps
+    // to do their specific logic with their bundles
+    var bundles = req.mendel.getBundleEntries();
+
+    // In this particular case, we used "temporary" on the .mendelrc
+    // go expose our lazy bundle entries from extractify
+    var lazy =  [
+        '<script>',
+        '   (function(){',
+        '       var nameSpace = "_extractedModuleBundleMap";',
+        '       var url = "'+req.mendel.getURL(bundle, variations)+'";',
+        '       window[nameSpace] = window[nameSpace] || {};',
+        '       ' + bundles[bundle].map(function(entry) {
+                    return 'window[nameSpace]["'+entry+'"] = ' + ' url;';
+                }).join('\n       '),
+        '   })()',
+        '</script>'
+    ];
+    return lazy.join('\n');
 }
 
 module.exports = app;

--- a/examples/full-example/isomorphic/base/components/body.js
+++ b/examples/full-example/isomorphic/base/components/body.js
@@ -15,12 +15,22 @@ class Body extends React.Component {
     }
 
     handleClick() {
+        var self = this;
         if (!this.state.loaded) {
-            Lazy = require('./lazy').default;
-
-            this.setState({
-                loaded:true
-            });
+            loadAsyncModule(
+                function inputRequire() {
+                    return require('./lazy');
+                },
+                function success(module) {
+                    Lazy = module.default;
+                    self.setState({
+                        loaded:true
+                    });
+                },
+                function failure() {
+                    alert('Something went wrong');
+                }
+            );
         }
     }
 
@@ -41,6 +51,64 @@ class Body extends React.Component {
             </section>
         );
     }
+}
+
+function loadAsyncModule(requireModule, successCallback, failureCallback) {
+    try {
+        var module = requireModule();
+        successCallback(module);
+    } catch (error) {
+        asyncRequire(requireModule, function(error, payload) {
+            if (error) {
+                return failureCallback(error);
+            }
+            successCallback(payload);
+        });
+    }
+}
+
+function asyncRequire(requireModule, callback) {
+    var parentRequire = window.require;
+    window.require = function(path) {
+        var self = this;
+        try {
+            var payload = parentRequire.apply(
+                this, Array.prototype.slice.call(arguments));
+            callback(null, payload);
+        } catch (error) {
+            if (error.code !== 'MODULE_NOT_FOUND') {
+                return callback(error);
+            }
+            loadScript(window._extractedModuleBundleMap[path], function(){
+                var payload = parentRequire.call(self, path);
+                callback(null, payload);
+            });
+        }
+    }
+    requireModule();
+    window.require = parentRequire;
+}
+
+function loadScript(url, callback) {
+    var script = document.createElement("script")
+    script.type = "text/javascript";
+
+    if (script.readyState){  //IE
+        script.onreadystatechange = function(){
+            if (script.readyState == "loaded" ||
+                    script.readyState == "complete"){
+                script.onreadystatechange = null;
+                callback();
+            }
+        };
+    } else {  //Others
+        script.onload = function(){
+            callback();
+        };
+    }
+
+    script.src = url;
+    document.getElementsByTagName("head")[0].appendChild(script);
 }
 
 export default Body;

--- a/packages/mendel-development-middleware/index.js
+++ b/packages/mendel-development-middleware/index.js
@@ -44,6 +44,40 @@ function MendelMiddleware(opts) {
     return function(req, res, next) {
         req.mendel = req.mendel || {};
 
+        req.mendel.getBundleEntries = function() {
+            console.log(bundles)
+            return Object.keys(bundles).reduce(
+
+                function(outputBundles, id) {
+                    var bundle = bundles[id];
+                    var outputEntries = [];
+
+                    [].concat(bundle.entries).filter(Boolean).forEach(
+                        function(entry) {
+                            existingVariations.forEach(function(variation) {
+                                variation.chain.forEach(function(dirPath) {
+                                    var absolutePath = path.resolve(
+                                        config.basedir, dirPath, entry
+                                    );
+                                    if (-1 === outputEntries
+                                        .indexOf(absolutePath)
+                                    ){
+                                        outputEntries.push(absolutePath);
+                                    }
+
+                                });
+                            });
+                        }
+                    );
+
+                    outputBundles[id] = outputEntries;
+                    return outputBundles;
+                },
+
+                {} // outputBundles
+            );
+        };
+
         req.mendel.getURL = function(bundle, variations) {
             var vars = variations.join(',') || config.base;
             return getPath({bundle: bundle, variations: vars});

--- a/packages/mendel-development-middleware/index.js
+++ b/packages/mendel-development-middleware/index.js
@@ -46,15 +46,12 @@ function MendelMiddleware(opts) {
         return allDirs;
     }, []);
 
-    console.log(allDirs);
-
     var loader = new MendelLoader(existingVariations, config, module.parent);
 
     return function(req, res, next) {
         req.mendel = req.mendel || {};
 
         req.mendel.getBundleEntries = function() {
-            console.log(bundles)
             return Object.keys(bundles).reduce(
 
                 function(outputBundles, id) {

--- a/packages/mendel-middleware/index.js
+++ b/packages/mendel-middleware/index.js
@@ -24,6 +24,23 @@ function MendelMiddleware(opts) {
     return function(req, res, next) {
         req.mendel = req.mendel || {};
 
+        req.mendel.getBundleEntries = function() {
+            return Object.keys(trees.bundles).reduce(
+
+                function(outputBundles, id) {
+                    var bundleDeps = trees.bundles[id].bundles;
+                    outputBundles[id] = bundleDeps.filter(function(dep) {
+                        return !!dep.expose || !!dep.entry;
+                    }).map(function(dep) {
+                        return dep.id;
+                    });
+                    return outputBundles;
+                },
+
+                {} // outputBundles
+            );
+        };
+
         req.mendel.getURL = function(bundle, variations) {
             var tree = trees.findTreeForVariations(bundle, variations);
             return getPath({ bundle: bundle, hash: tree.hash });


### PR DESCRIPTION
The idea of this PR is to demonstrate a way to give enough information to the applications using mendel, without changing the     performance characteristics we have. We are avoiding at all cost calling `findTreeForVariations` without real need.

If we ever have more than one method that needs it, we will need caching per request or maybe change to a stateful API.

@tufandevrim this is a counter-proposal for #34