### PR TITLE
Groundwork to support extractify-like algorithm on Mendel CLI; Flattens arrays, verbose mode and normalize entries

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -15,20 +15,31 @@ var applyExtraOptions = require('mendel-development/apply-extra-options');
 var mendelBrowserify = require('mendel-browserify');
 var mendelRequirify = require('mendel-requirify');
 
+var debug = process.argv.some(function(arg) {
+    return /--verbose/.test(arg);
+});
+
 var rawConfig = parseConfig();
-logObj(rawConfig);
 
 var outdir = rawConfig.bundlesoutdir || rawConfig.outdir;
 mkdirp.sync(outdir);
 
 var config = ['basedir','outdir','bundlesoutdir','serveroutdir',
     'base','basetree','variationsroute','hashroute',
-    'variationsdir','variations', 'bundles'].reduce(function(cfg, key) {
+    'variationsdir','variations'].reduce(function(cfg, key) {
         cfg[key] = rawConfig[key];
         return cfg;
-    }, {});
+    }, {
+        config: false,
+    });
 
-async.each(config.bundles, function(rawBundle, doneBundle) {
+if(debug) {
+    config.verbose = true;
+    console.log('mendel parsed config');
+    logObj(config);
+}
+
+async.each(rawConfig.bundles, function(rawBundle, doneBundle) {
     var bundle = JSON.parse(JSON.stringify(rawBundle));
     var conf = {
         basedir: config.basedir,
@@ -36,10 +47,12 @@ async.each(config.bundles, function(rawBundle, doneBundle) {
             config.bundlesoutdir, config.base, bundle.bundleName + '.js'
         )
     };
+
     mkdirp.sync(path.dirname(conf.outfile));
 
-    var entries = bundle.entries;
-    delete bundle.entries;
+    flattenFilenameArrays(bundle);
+
+    bundle.entries = normalizeEntries(bundle.entries);
 
     var b = browserify(xtend(conf, bundle));
     b.plugin(mendelBrowserify, config);
@@ -52,13 +65,6 @@ async.each(config.bundles, function(rawBundle, doneBundle) {
 
     applyExtraOptions(b, bundle);
 
-    if (entries) {
-        // TODO: aync ../lib/resolve-dirs instead of hardcoded base
-        entries.forEach(function(entry) {
-            b.add(path.join(config.basedir, config.basetree, entry));
-        });
-    }
-
     var finalBundle = b.bundle();
     finalBundle.on('end', doneBundle);
     if (conf.outfile) {
@@ -67,6 +73,45 @@ async.each(config.bundles, function(rawBundle, doneBundle) {
         finalBundle.pipe(process.stdout);
     }
 });
+
+function normalizeEntries(entries) {
+    return [].concat(entries).filter(Boolean)
+    .map(function(entry) {
+        if (typeof entry === 'string') {
+            if(!fs.existsSync(path.join(config.basedir, entry))) {
+                var messages = [
+                    '[warn] paths relative to variation are deprecated',
+                    'you can fix this by changing',
+                    entry,
+                    'in your configuration'
+                ];
+                console.log(messages.join(' '));
+                entry = path.join(config.basedir, config.basetree, entry);
+            }
+        }
+        return entry;
+    });
+}
+
+function flattenFilenameArrays(bundle) {
+    ['entries', 'require', 'external', 'exclude', 'ignore']
+    .forEach(function(param) {
+        var inputArray = bundle[param]
+        if (!Array.isArray(inputArray)) return;
+
+        var i = 0;
+        while (i <= inputArray.length) {
+            var item = inputArray[i];
+            if (Array.isArray(item)) {
+                Array.prototype.splice.apply(
+                    inputArray,
+                    [i, 1].concat(item)
+                );
+            }
+            i++;
+        }
+    });
+}
 
 function logObj(obj) {
   console.log(require('util').inspect(obj,false,null,true));

--- a/packages/mendel-browserify/index.js
+++ b/packages/mendel-browserify/index.js
@@ -16,6 +16,7 @@ var resolveInDirs = require('mendel-treenherit/resolve-dirs');
 var mendelify = require('mendel-development/mendelify-transform-stream');
 var proxy = require('mendel-development/proxy');
 var tmp = require('tmp');
+var inspect = require('util').inspect;
 var onlyPublicMethods = proxy.onlyPublicMethods;
 
 module.exports = MendelBrowserify;
@@ -64,14 +65,17 @@ function MendelBrowserify(baseBundle, pluginOptions) {
     this.variations = validVariations(pluginOptions);
     this.variationsWithBase = [this.baseVariation].concat(this.variations);
 
-    console.log('mendel-browserify config', require('util').inspect({
-        baseOptions: baseOptions,
-        pluginOptions: pluginOptions,
-        variationsWithBase: this.variationsWithBase,
-    }, {
-        colors: true,
-        depth: null,
-    }));
+    pluginOptions.verbose && console.log(
+        'mendel-browserify config \n',
+        inspect({
+            baseOptions: baseOptions,
+            pluginOptions: pluginOptions,
+            variationsWithBase: this.variationsWithBase,
+        }, {
+            colors: true,
+            depth: null,
+        })
+    );
 
 
     this.prepareBundle(baseBundle, this.baseVariation);


### PR DESCRIPTION
This fixes the verbose output by default, making it an option.
It also makes it possible to do nested arrays in .mendelrc files, which is specifically useful for yaml files. Here is a simple example:

```yml
sharedConfig:
  vendorLibs: &vendorLibs
    - react
    - react-dom
    - react-nice-plugin
    - lodash/is/cool
  onDemandBundle: &onDemandBundle
    - ./src/less-used-feature.jsx

bundles:
  main:
    entries:
      - ./src/main.js
    external:
      - *vendorLibs
      - *onDemandBundle
  less-used:
    external: *vendorLibs
    require: *onDemandBundle
```

We are also deprecating use of relative paths on entries with a warn message.

@tufandevrim can you review?