### PR TITLE
Post manifest architecture, mendel-manifest-extract-bundles and example on how to use it

### DIFF
--- a/bin/post-process-manifest.js
+++ b/bin/post-process-manifest.js
@@ -1,0 +1,117 @@
+/* Copyright 2015, Yahoo Inc.
+   Copyrights licensed under the MIT License.
+   See the accompanying LICENSE file for terms. */
+
+var fs = require('fs');
+var path = require('path');
+var async = require('async');
+var inspect = require('util').inspect;
+var resolve = require('resolve');
+
+var sortManifest = require('mendel-development/sort-manifest');
+var validateManifest = require('mendel-development/validate-manifest');
+
+module.exports = postProcessManifests;
+
+function postProcessManifests(config) {
+    var resolveProcessor = processorResolver.bind(null, config);
+
+    var processors = [
+        [loadManifests, config]
+    ].concat(config.manifestProcessors).concat([
+        [sortManifestProcessor, config],
+        [validateManifestProcessor, config],
+        [writeManifest, config]
+    ]);
+
+    async.map(processors, resolveProcessor, function(err, processors) {
+        if (err) throw err;
+        var input = config.bundles;
+
+        async.eachSeries(processors,
+        function(processorPair, doneStep) {
+            var processor = processorPair[0];
+            var opts = processorPair[1];
+            if(config.verbose) {
+                opts.verbose = config.verbose;
+                console.log('Running manifest processor', inspect(processor));
+            }
+
+            processor(input, opts, function(output) {
+                input = output;
+                doneStep();
+            });
+        });
+    });
+}
+
+function processorResolver(config, processorIn, doneProcessor) {
+    if (!Array.isArray(processorIn)) {
+        return processorResolver(config, [processorIn, {}], doneProcessor);
+    }
+
+    var processor = processorIn[0];
+    var opts = processorIn[1];
+    if (typeof processor === 'string') {
+        var resolveOpts = {
+            basedir: config.basedir
+        };
+        resolve(processor, resolveOpts, function (err, path) {
+            if (err) return doneProcessor(err);
+            var newProcessor = [require(path), opts];
+            doneProcessor(null, newProcessor);
+        });
+    } else {
+        doneProcessor(null, processorIn);
+    }
+}
+
+function loadManifests(bundles, config, next) {
+    var manifests = bundles.reduce(function(manifests, bundle) {
+        manifests[bundle.bundleName] = require(
+            path.join(config.outdir, bundle.manifest)
+        );
+        return manifests;
+    }, {});
+    next(manifests);
+}
+
+function sortManifestProcessor(manifests, config, next) {
+    Object.keys(manifests).forEach(function(bundleName) {
+        manifests[bundleName] = (sortManifest(
+            manifests[bundleName].indexes,
+            manifests[bundleName].bundles
+        ));
+    });
+    next(manifests);
+}
+
+function validateManifestProcessor(manifests, config, next) {
+    Object.keys(manifests).forEach(function(bundleName) {
+        var filename = config.bundles.filter(function(bundle) {
+            return bundle.bundleName === bundleName;
+        })[0].manifest;
+        validateManifest(
+            manifests[bundleName],
+            filename,
+            'manifestProcessors'
+        );
+    });
+    next(manifests);
+}
+
+function writeManifest(manifests, config, next) {
+    Object.keys(manifests).forEach(function(bundleName) {
+        var filename = config.bundles.filter(function(bundle) {
+            return bundle.bundleName === bundleName;
+        })[0].manifest;
+        fs.writeFileSync(
+            path.join(config.outdir, filename),
+            JSON.stringify(manifests[bundleName], null, 2)
+        );
+    });
+    next();
+}
+
+
+

--- a/examples/full-example/.mendelrc
+++ b/examples/full-example/.mendelrc
@@ -12,9 +12,7 @@ bundles:
       - react-dom
   main:
     entries:
-      - main.js
-    require:
-      - ./isomorphic/base/components/button.js
+      - ./isomorphic/base/main.js
     external:
       - react
       - react-dom
@@ -27,9 +25,14 @@ bundles:
     external:
       - react
       - react-dom
-      - ./isomorphic/base/components/button.js
     transform:
       - babelify
+
+manifestProcessors:
+  -
+    - mendel-manifest-extract-bundles
+    - external: lazy
+      from: main
 
 variationsdir: isomorphic/variations
 variations:

--- a/examples/full-example/package.json
+++ b/examples/full-example/package.json
@@ -22,6 +22,7 @@
     "babelify": "^7.3.0",
     "eslint-plugin-react": "^5.0.1",
     "mendel": "*",
+    "mendel-manifest-extract-bundles": "*",
     "mendel-development-middleware": "*",
     "mendel-extractify": "*",
     "nodemon": "^1.9.2"

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "exclude": [
       "examples/**",
       "coverage/**",
-      "test/**",
-      "packages/*/lib/**"
+      "test/**"
     ]
   },
   "dependencies": {
@@ -69,6 +68,7 @@
     "rimraf": "^2.5.2",
     "tap": "^5.7.0",
     "temp": "^0.8.3",
-    "through2": "^2.0.1"
+    "through2": "^2.0.1",
+    "tmp": "0.0.28"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Build toolchain for experimentation on isomorphic web applications with tree-inheritance and multivariate support.",
   "keywords": [
     "testing",
@@ -58,7 +58,7 @@
     "xtend": "^4.0.1",
     "mendel-config": "^1.0.5",
     "mendel-browserify": "^1.0.8",
-    "mendel-development": "^1.0.9",
+    "mendel-development": "^1.0.10",
     "mendel-requirify": "^1.0.7"
   },
   "devDependencies": {

--- a/packages/mendel-browserify/index.js
+++ b/packages/mendel-browserify/index.js
@@ -209,7 +209,7 @@ MendelBrowserify.prototype.createManifest = function(bundle) {
     ++ self._manifestPending;
     bundle.on('bundle', function(b) { b.on('end', function() {
         if (-- self._manifestPending === 0) {
-            self.doneManifest(bundle);
+            self.doneManifest(self.baseBundle);
         }
     });});
 };
@@ -258,7 +258,7 @@ MendelBrowserify.prototype.pushBundleManifest = function(dep) {
     }
 };
 
-MendelBrowserify.prototype.doneManifest = function() {
+MendelBrowserify.prototype.doneManifest = function(bundle) {
     var bundleManifest = sortManifest(
         this._manifestIndexes,
         this._manifestBundles
@@ -271,10 +271,14 @@ MendelBrowserify.prototype.doneManifest = function() {
         this.pluginOptions.manifest
     );
 
-    validateManifest(bundleManifest, manifest);
+    validateManifest(bundleManifest, manifest, 'mendel-browserify');
 
-    fs.writeFileSync(
-        manifest, JSON.stringify(bundleManifest, null, 2)
+    fs.writeFile(
+        manifest, JSON.stringify(bundleManifest, null, 2),
+        function(err) {
+            if (err) throw err;
+            bundle.emit('manifest');
+        }
     );
 };
 

--- a/packages/mendel-development/package.json
+++ b/packages/mendel-development/package.json
@@ -17,8 +17,9 @@
   },
   "dependencies": {
     "falafel": "^1.2.0",
+    "glob": "^7.0.3",
     "shasum": "^1.0.2",
     "through2": "^2.0.1",
-    "glob": "^7.0.3"
+    "tmp": "0.0.28"
   }
 }

--- a/packages/mendel-development/sort-manifest.js
+++ b/packages/mendel-development/sort-manifest.js
@@ -1,0 +1,33 @@
+/* Copyright 2015, Yahoo Inc.
+   Copyrights licensed under the MIT License.
+   See the accompanying LICENSE file for terms. */
+
+module.exports = sortManifest;
+
+function sortManifest(inputIndexes, inputBundles) {
+    var sortedManifest = {
+        indexes: {},
+        bundles: []
+    };
+
+    Object.keys(inputIndexes).sort().forEach(function(file) {
+        var bundle = inputBundles[inputIndexes[file]];
+        sortedManifest.bundles.push(bundle);
+
+        var index = sortedManifest.bundles.indexOf(bundle);
+        sortedManifest.indexes[file] = index;
+        bundle.index = index;
+
+        bundle.data.forEach(function(dep) {
+            var oldSubDeps = dep.deps;
+            var newSubDeps = {};
+            Object.keys(oldSubDeps).sort().forEach(function(key) {
+                newSubDeps[key] = oldSubDeps[key];
+            });
+            dep.deps = newSubDeps;
+        });
+
+    });
+
+    return sortedManifest;
+}

--- a/packages/mendel-development/validate-manifest.js
+++ b/packages/mendel-development/validate-manifest.js
@@ -58,6 +58,8 @@ function validateManifest(manifest, originalPath, stepName) {
         fs.writeFileSync(destination, JSON.stringify(manifest, null, 2));
 
         console.log('\n' + destination + ' written \n');
-        process.exit(2);
+        var e = new Error('Invalid manifest');
+        e.code = "INVALID_MANIFEST";
+        throw e;
     }
 }

--- a/packages/mendel-development/validate-manifest.js
+++ b/packages/mendel-development/validate-manifest.js
@@ -8,7 +8,7 @@ var tmp = require('tmp');
 
 module.exports = validateManifest;
 
-function validateManifest(manifest, originalPath) {
+function validateManifest(manifest, originalPath, stepName) {
     var errors = [];
 
     var requires = /require\(['"](.*?)['"]\)/g;
@@ -47,7 +47,7 @@ function validateManifest(manifest, originalPath) {
     });
 
     if (errors.length) {
-        console.log('\nmendel-browserify compilation errors: \n');
+        console.log('\n'+stepName+' manifest errors: \n');
         errors.forEach(function(log){
             console.log('  ' + log);
         });

--- a/packages/mendel-development/validate-manifest.js
+++ b/packages/mendel-development/validate-manifest.js
@@ -1,0 +1,63 @@
+/* Copyright 2015, Yahoo Inc.
+   Copyrights licensed under the MIT License.
+   See the accompanying LICENSE file for terms. */
+
+var path = require('path');
+var fs = require('fs');
+var tmp = require('tmp');
+
+module.exports = validateManifest;
+
+function validateManifest(manifest, originalPath) {
+    var errors = [];
+
+    var requires = /require\(['"](.*?)['"]\)/g;
+    var multilineComments = /\/\*(?:\n|.)*\*\//gm;
+    var endOfLineComments = /\/\/\*.*/g;
+
+    manifest.bundles.forEach(function(bundle) {
+        bundle.data.forEach(function(row) {
+            var depNames = Object.keys(row.deps);
+
+            // Find require() on source that don't have a key in deps
+            var noCommentsSource = row.source
+                                      .replace(multilineComments, '')
+                                      .replace(endOfLineComments, '');
+            var match;
+            while ((match = requires.exec(noCommentsSource)) !== null) {
+                if (-1 === depNames.indexOf(match[1])) {
+                    errors.push(
+                        "can't require '" + match[1] + "' from " + row.id
+                    );
+                }
+            }
+
+            // Find dependencies not included in the manifest
+            depNames.forEach(function(key) {
+                var externalModule = row.deps[key] === false;
+                var existsInManifest = row.deps[key] in manifest.indexes;
+
+                if (!externalModule && !existsInManifest) {
+                    errors.push(
+                        key + ":" + row.deps[key] +
+                                        ' missing from '+ bundle.id);
+                }
+            });
+        });
+    });
+
+    if (errors.length) {
+        console.log('\nmendel-browserify compilation errors: \n');
+        errors.forEach(function(log){
+            console.log('  ' + log);
+        });
+
+        var tempDir = tmp.dirSync().name;
+        var filename = 'debug.' + path.parse(originalPath).base;
+        var destination = path.resolve(tempDir, filename);
+        fs.writeFileSync(destination, JSON.stringify(manifest, null, 2));
+
+        console.log('\n' + destination + ' written \n');
+        process.exit(2);
+    }
+}

--- a/packages/mendel-manifest-extract-bundles/manifest-extract.js
+++ b/packages/mendel-manifest-extract-bundles/manifest-extract.js
@@ -15,6 +15,7 @@ function manifestExtractBundles(manifests, options, next) {
         return fromFiles.indexOf(file) >= 0;
     });
 
+    // istanbul ignore if
     if(options.verbose) {
         console.log([
             'found', intersection.length, 'files intersecting between',
@@ -56,6 +57,7 @@ function manifestExtractBundles(manifests, options, next) {
         });
     });
 
+    // istanbul ignore if
     if (options.verbose) {
         var remaining = Object.keys(externalManifest.indexes).length;
         console.log([

--- a/packages/mendel-manifest-extract-bundles/manifest-extract.js
+++ b/packages/mendel-manifest-extract-bundles/manifest-extract.js
@@ -1,0 +1,68 @@
+/* Copyright 2015, Yahoo Inc.
+   Copyrights licensed under the MIT License.
+   See the accompanying LICENSE file for terms. */
+
+module.exports = manifestExtractBundles;
+
+function manifestExtractBundles(manifests, options, next) {
+    var fromManifest = manifests[options.from];
+    var externalManifest = manifests[options.external];
+
+    var fromFiles = Object.keys(fromManifest.indexes);
+    var externalFiles = Object.keys(externalManifest.indexes);
+
+    var intersection = externalFiles.filter(function(file) {
+        return fromFiles.indexOf(file) >= 0;
+    });
+
+    if(options.verbose) {
+        console.log([
+            'found', intersection.length, 'files intersecting between',
+            options.from, 'and', options.external
+        ].join(' '));
+    }
+
+    // Expose files on the source bundle
+    intersection.forEach(function(file) {
+        var moduleIndex = fromManifest.indexes[file];
+        var bundle = fromManifest.bundles[moduleIndex];
+        bundle.expose = bundle.id;
+        bundle.variations.forEach(function(variation, index) {
+            bundle.data[index].expose = bundle.id;
+        });
+    });
+
+    // Make modules external on the external bundle
+    // By removing files from the index, when the manifest is sorted and
+    // validated, unreachable modules are removed.
+    externalManifest.indexes = externalFiles.reduce(function(indexes, file) {
+        if (-1 === intersection.indexOf(file)) {
+            indexes[file] = externalManifest.indexes[file];
+        }
+        return indexes;
+    }, {});
+
+    // Also, we need to make sure deps are updated to "false", which marks
+    // the dep as external
+    Object.keys(externalManifest.indexes).forEach(function(file) {
+        var bundle = externalManifest.bundles[externalManifest.indexes[file]];
+        bundle.data.forEach(function(module) {
+            Object.keys(module.deps).forEach(function(key) {
+                var value = module.deps[key];
+                if (intersection.indexOf(value) >=0) {
+                    module.deps[key] = false;
+                }
+            });
+        });
+    });
+
+    if (options.verbose) {
+        var remaining = Object.keys(externalManifest.indexes).length;
+        console.log([
+            remaining, 'files remaining in',
+            options.external, 'after extraction'
+        ].join(' '));
+    }
+
+    next(manifests);
+}

--- a/packages/mendel-manifest-extract-bundles/package.json
+++ b/packages/mendel-manifest-extract-bundles/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mendel-manifest-extract-bundles",
+  "version": "0.0.1",
+  "description": "Parses a list of manifests, extract common dependencies and expose them from the parent bundle.",
+  "main": "manifest-extract.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "mendel",
+    "mendel-manifest-processor",
+    "build"
+  ],
+  "author": "Irae Carvalho <irae@irae.pro.br>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yahoo/mendel"
+  },
+  "dependencies": {
+    "mendel-development": "^1.0.10"
+  }
+}

--- a/test/manifest-extract.js
+++ b/test/manifest-extract.js
@@ -1,0 +1,63 @@
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var tmp = require('tmp');
+
+// Since this file re-writes stuff, lets work on a copy
+var realSamples = path.join(__dirname, './manifest-samples/');
+var copySamples = tmp.dirSync().name;
+
+var postProcessManifests = require('../bin/post-process-manifest');
+var extract = require('../packages/mendel-manifest-extract-bundles');
+
+test('postProcessManifests applying post-processors', function (t) {
+    copyRecursiveSync(realSamples, copySamples);
+    t.plan(4);
+
+    postProcessManifests({
+        // verbose: true, // remember to use this for debug
+        manifestProcessors:[
+            [extract, {
+                from: "bad-sort",
+                external: "foo-is-children"
+            }],
+        ],
+        outdir: copySamples,
+        bundles: [{
+            // just re-using, important part is that are some files there
+            bundleName: 'bad-sort',
+            manifest: 'bad-sort.manifest.json'
+        }, {
+            bundleName: 'foo-is-children',
+            manifest: 'foo-is-children.manifest.json'
+        }],
+    }, function(error) {
+        t.error(error);
+        var resultFrom = require(
+            path.join(copySamples, 'bad-sort.manifest.json'));
+        var resultExternal = require(
+            path.join(copySamples, 'foo-is-children.manifest.json'));
+        t.equals(resultExternal.bundles.length, 2, 'removed external bundles');
+        t.equals(resultFrom.bundles[1].expose,
+            'foo', 'exposed bundle');
+        t.equals(resultFrom.bundles[1].data[0].expose,
+            'foo', 'exposed variation');
+    });
+});
+
+
+
+function copyRecursiveSync(src, dest) {
+  var exists = fs.existsSync(src);
+  var stats = exists && fs.statSync(src);
+  var isDirectory = exists && stats.isDirectory();
+  if (exists && isDirectory) {
+    try{fs.mkdirSync(dest);} catch(e) {/**/}
+    fs.readdirSync(src).forEach(function(childItemName) {
+      copyRecursiveSync(path.join(src, childItemName),
+                        path.join(dest, childItemName));
+    });
+  } else {
+    fs.writeFileSync(dest, fs.readFileSync(src));
+  }
+}

--- a/test/manifest-samples/bad-sort.manifest.json
+++ b/test/manifest-samples/bad-sort.manifest.json
@@ -1,0 +1,36 @@
+{
+  "indexes": {
+    "zoo": 0,
+    "foo": 1,
+    "bar": 2
+  },
+  "bundles": [
+    {"variations": ["var"],
+    "id": "zoo",
+    "data": [{
+      "source": "",
+      "deps": {}
+    }]},
+    {"variations": ["var"],
+    "id": "foo",
+    "data": [{
+      "source": "",
+      "deps": {
+        "zoo":"zoo",
+        "bar":"bar"
+      }
+    }]},
+    {"variations": ["var"],
+    "id": "bar",
+    "data": [{
+      "source": "",
+      "deps": {}
+    }]},
+    {"variations": ["var"],
+    "id": "dont-exists",
+    "data": [{
+      "source": "",
+      "deps": {}
+    }]}
+  ]
+}

--- a/test/manifest-samples/bad.manifest.json
+++ b/test/manifest-samples/bad.manifest.json
@@ -1,0 +1,14 @@
+{
+  "indexes": {
+    "foo": 0
+  },
+  "bundles": [{
+    "variations": ["bar"],
+    "data": [{
+      "source": "",
+      "deps": {
+        "nope":"baz"
+      }
+    }]
+  }]
+}

--- a/test/manifest-samples/foo-is-children.manifest.json
+++ b/test/manifest-samples/foo-is-children.manifest.json
@@ -1,0 +1,29 @@
+{
+  "indexes": {
+    "foo": 0,
+    "parent": 1,
+    "other": 2
+  },
+  "bundles": [{
+    "variations": ["var"],
+    "data": [{
+      "source": "",
+      "deps": {}
+    }]
+  },{
+    "variations": ["var"],
+    "data": [{
+      "source": "",
+      "deps": {
+        "foo":"foo",
+        "other": "other"
+      }
+    }]
+  },{
+    "variations": ["var"],
+    "data": [{
+      "source": "",
+      "deps": {}
+    }]
+  }]
+}

--- a/test/manifest-samples/minimal.manifest.json
+++ b/test/manifest-samples/minimal.manifest.json
@@ -1,0 +1,12 @@
+{
+  "indexes": {
+    "foo": 0
+  },
+  "bundles": [{
+    "variations": ["bar"],
+    "data": [{
+      "source": "",
+      "deps": {}
+    }]
+  }]
+}

--- a/test/post-process-manifest.js
+++ b/test/post-process-manifest.js
@@ -1,0 +1,113 @@
+var test = require('tap').test;
+var fs = require('fs');
+var path = require('path');
+var tmp = require('tmp');
+
+// Since this file re-writes stuff, lets work on a copy
+var realSamples = path.join(__dirname, './manifest-samples/');
+var copySamples = tmp.dirSync().name;
+
+var postProcessManifests = require('../bin/post-process-manifest');
+
+test('postProcessManifests loads manifests', function (t) {
+    copyRecursiveSync(realSamples, copySamples);
+    t.plan(1);
+
+    postProcessManifests({
+        outdir: copySamples,
+        bundles: [{
+            bundleName: 'minimal',
+            manifest: 'minimal.manifest.json'
+        }],
+    }, t.error);
+});
+
+test('postProcessManifests sorts and cleans manifests', function (t) {
+    copyRecursiveSync(realSamples, copySamples);
+    t.plan(4);
+
+    postProcessManifests({
+        outdir: copySamples,
+        bundles: [{
+            bundleName: 'bad-sort',
+            manifest: 'bad-sort.manifest.json'
+        }],
+    }, function(error) {
+        t.error(error);
+        var result = require(path.join(copySamples, 'bad-sort.manifest.json'));
+
+        t.equal(result.bundles.length, 3, 'removed one unused bundle');
+        t.deepEqual(result.indexes,
+            { bar: 0, foo: 1, zoo: 2 }, 'reordered indexes');
+        t.deepEqual(Object.keys(result.bundles[1].data[0].deps),
+            ["bar", "zoo"], 'reordered deps');
+    });
+});
+
+
+test('postProcessManifests validates manifests', function (t) {
+    copyRecursiveSync(realSamples, copySamples);
+    t.plan(1);
+
+    postProcessManifests({
+        outdir: copySamples,
+        bundles: [{
+            bundleName: 'bad',
+            manifest: 'bad.manifest.json'
+        }],
+    }, function(err) {
+        t.equal(err.code, "INVALID_MANIFEST", "should validate manifests");
+    });
+});
+
+
+test('postProcessManifests applying post-processors', function (t) {
+    copyRecursiveSync(realSamples, copySamples);
+    t.plan(4);
+
+    var calls = [];
+    function passThroughProcessor(manifests, config, next) {
+        calls.push(arguments);
+        next(manifests);
+    }
+    // yup, kinda nasty, but oh well, it is just tests
+    module.exports = function secondPassThrough(manifests, config, next) {
+        calls.push('external file');
+        next(manifests);
+    };
+    postProcessManifests({
+        manifestProcessors:[
+            [passThroughProcessor, {'LMAO':"the french smiley cat"}],
+            path.resolve(__filename)
+        ],
+        outdir: copySamples,
+        bundles: [{
+            bundleName: 'minimal',
+            manifest: 'minimal.manifest.json'
+        }],
+    }, function(error) {
+        t.error(error);
+        t.equals(calls.length, 2, 'calls the post-processors');
+        t.equals(calls[0][1].LMAO,
+            "the french smiley cat", 'pass correct options');
+        t.equals(calls[1],
+            'external file', 'loads external processors');
+    });
+});
+
+
+
+function copyRecursiveSync(src, dest) {
+  var exists = fs.existsSync(src);
+  var stats = exists && fs.statSync(src);
+  var isDirectory = exists && stats.isDirectory();
+  if (exists && isDirectory) {
+    try{fs.mkdirSync(dest);} catch(e) {/**/}
+    fs.readdirSync(src).forEach(function(childItemName) {
+      copyRecursiveSync(path.join(src, childItemName),
+                        path.join(dest, childItemName));
+    });
+  } else {
+    fs.writeFileSync(dest, fs.readFileSync(src));
+  }
+}

--- a/test/trees.js
+++ b/test/trees.js
@@ -124,7 +124,7 @@ test('MendelTrees valid manifest runtime', function (t) {
     process.chdir(appPath);
     mkdirp.sync(appBuild);
     exec('./run.sh', { cwd: appPath }, function(error) {
-        if (error) return t.fail('should create manifest but failed', error);
+        if (error) return t.bailout('should create manifest but failed', error);
 
         var trees = MendelTrees();
         var variationCount = trees.variations.length;


### PR DESCRIPTION
This PR is a bit large but it is easy to understand commit by commit.

The first one is pretty straight forward, it just moves code around to be used on the later commits.

The second commit introduces a new `.mendelrc` feature, the `manifestProcessors`. Here is how it is supposed to be used:

```yaml
manifestProcessors:
  - ./my-path/post-process-manifest.js
  -
    - postprocessor-npm-module
    - option1: strvalue
      option2: true
```

Any post processor will be loaded relative to `basedir` or from the project `package.json`. And every post processor has the following signature:

```js
module.exports = function processorName(allManifests, options, next) {
    // do your stuff with all manifests
   next(newManifestObject);
};
```

All manifests are also re-sorted and validated by the same functions we use in other places in the codebase (extracted in the first commit.

The last commit introduces a new package `mendel-manifest-extract-bundles` that does the same as extractify, but only as a post processor for mendel.

Here is a simplified version of the `full-example` code that uses this new processor: 

```yaml
bundles:
  main:
    entries:
      - ./isomorphic/base/main.js
    external:
      - ./isomorphic/base/components/lazy.js
  lazy:
    require:
      - ./isomorphic/base/components/lazy.js
    ## not needed anymore
    ## external:
    ##   - ./isomorphic/base/components/button.js

manifestProcessors:
  -
    - mendel-manifest-extract-bundles
    - external: lazy
      from: main
```

The externals are simple in our full example, but can be hundreds of files in real applications.

You can also run `mendel --verbose` to see a lot of useful information to understand the code better.

@tufandevrim 