### PR TITLE
req.mendel.resolver requires bundles array to improve performance

### DIFF
--- a/examples/full-example/app.js
+++ b/examples/full-example/app.js
@@ -22,7 +22,9 @@ app.get('/', function(req, res) {
     var optionalMarkup = "";
 
     if (serverRender) {
-        var resolver = req.mendel.resolver(variations);
+        // To improve ssr performance, you need to pass
+        // array of bundle ids you only need for ssr rendering
+        var resolver = req.mendel.resolver(['main'], variations);
         var Main = resolver.require('main.js');
 
         optionalMarkup = ReactDOMServer.renderToString(Main())

--- a/packages/mendel-core/package.json
+++ b/packages/mendel-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-core",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "Mendel shared dependencies production use",
   "main": "trees.js",
   "scripts": {

--- a/packages/mendel-core/trees.js
+++ b/packages/mendel-core/trees.js
@@ -42,7 +42,7 @@ MendelTrees.prototype.findTreeForVariations = function(bundle, variations) {
     return finder.found();
 };
 
-MendelTrees.prototype.findServerVariationMap = function(variations) {
+MendelTrees.prototype.findServerVariationMap = function(bundles, variations) {
     if (typeof variations ==='string') {
         variations = [variations];
     }
@@ -53,7 +53,11 @@ MendelTrees.prototype.findServerVariationMap = function(variations) {
     var lookupChains = self._buildLookupChains(variations);
     var finder = new MendelServerVariationWalker(lookupChains, base);
 
-    Object.keys(self.bundles).forEach(function (bundle) {
+    function selectBundles(key) {
+        return bundles.indexOf(key) !== -1;
+    }
+
+    Object.keys(self.bundles).filter(selectBundles).forEach(function (bundle) {
         self._walkTree(bundle, finder);
         variationMap = xtend(variationMap, finder.found());
     });

--- a/packages/mendel-development-loader/loader.js
+++ b/packages/mendel-development-loader/loader.js
@@ -19,7 +19,7 @@ function MendelLoaderDev(existingVariations, config, parentModule) {
     this._checkSsrReady();
 }
 
-MendelLoaderDev.prototype.resolver = function(variations) {
+MendelLoaderDev.prototype.resolver = function(bundles, variations) {
     if (!this.isSsrReady()) {
         console.warn('Warning: Mendel loader could not find server output dir.');
     }

--- a/packages/mendel-development-loader/package.json
+++ b/packages/mendel-development-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development-loader",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Mendel development server side require hook.",
   "main": "loader.js",
   "scripts": {
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "mendel-development": "^1.1.0",
-    "mendel-loader": "^1.1.0"
+    "mendel-loader": "^2.0.0"
   }
 }

--- a/packages/mendel-development-middleware/package.json
+++ b/packages/mendel-development-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development-middleware",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "description": "express middleware for meldel",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "fs-extra": "^0.30.0",
     "mendel-config": "^1.1.1",
     "mendel-development": "^1.1.0",
-    "mendel-development-loader": "^1.1.0",
+    "mendel-development-loader": "^2.0.0",
     "mendel-requirify": "^1.0.6",
     "mendel-treenherit": "^1.0.6",
     "stream-cache": "0.0.2",

--- a/packages/mendel-loader/loader.js
+++ b/packages/mendel-loader/loader.js
@@ -26,8 +26,8 @@ function MendelLoader(trees, opts) {
     this._ssrReady = true;
 }
 
-MendelLoader.prototype.resolver = function(variations) {
-    var variationMap = this._trees.findServerVariationMap(variations);
+MendelLoader.prototype.resolver = function(bundles, variations) {
+    var variationMap = this._trees.findServerVariationMap(bundles, variations);
 
     return new MendelResolver(this._parentModule, variationMap, this._serveroutdir);
 };

--- a/packages/mendel-loader/package.json
+++ b/packages/mendel-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-loader",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Mendel server side require hook.",
   "main": "loader.js",
   "scripts": {

--- a/packages/mendel-middleware/package.json
+++ b/packages/mendel-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-middleware",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Mendel Middleware that uses generated manifests to output multilayer resolution of isomorphic applications.",
   "main": "index.js",
   "scripts": {
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "browser-pack": "^6.0.1",
-    "mendel-core": "^1.1.1",
-    "mendel-loader": "^1.0.5",
+    "mendel-core": "^2.0.0",
+    "mendel-loader": "^2.0.0",
     "path-to-regexp": "^1.2.1"
   }
 }

--- a/test/mendel-loader.js
+++ b/test/mendel-loader.js
@@ -62,7 +62,7 @@ test('mendel-loader-server', function(t){
             }];
 
             inputs.forEach(function (i) {
-                var resolver = loader.resolver(i.variations);
+                var resolver = loader.resolver(['app'], i.variations);
                 var variation = i.variations.join(',');
 
                 var someNumber = resolver.require('some-number.js');
@@ -101,7 +101,7 @@ test('mendel-loader-server-syntax-error', function(t){
         });
         // test without 'new'
         var loader = Loader(tree);
-        var resolver = loader.resolver(['test_B']);
+        var resolver = loader.resolver(['app'], ['test_B']);
 
         var invalidFile = path.join(srcDir, 'app/syntax-error.js');
         t.throws(function() {

--- a/test/trees.js
+++ b/test/trees.js
@@ -119,7 +119,7 @@ test('MendelTrees private methods', function (t) {
 });
 
 test('MendelTrees valid manifest runtime', function (t) {
-    t.plan(8);
+    t.plan(10);
 
     process.chdir(appPath);
     mkdirp.sync(appBuild);
@@ -148,8 +148,10 @@ test('MendelTrees valid manifest runtime', function (t) {
         t.match(result_1, decoded,
             'retrieves same tree from hahs');
 
-        var map_1 = trees.findServerVariationMap('test_A');
-        var map_2 = trees.findServerVariationMap(['test_A', 'test_B']);
+        var map_1 = trees.findServerVariationMap(['app'], 'test_A');
+        var map_2 = trees.findServerVariationMap(['app'], ['test_A', 'test_B']);
+        var map_3 = trees.findServerVariationMap(['foo'], 'test_A');
+        var map_4 = trees.findServerVariationMap([], 'test_A');
 
         t.match(map_1, {
             'index.js': 'app',
@@ -163,5 +165,7 @@ test('MendelTrees valid manifest runtime', function (t) {
             'some-number.js': 'test_B',
             'another-number.js': 'app'
         }, 'map_2 variationMap sanity check');
+        t.match(map_3, {}, 'map_3 variationMap sanity check');
+        t.match(map_4, {}, 'map_4 variationMap sanity check');
     });
 });


### PR DESCRIPTION
This PR intends to improve performance of `loader.resolver` function by only checking bundle list in `findServerVariationMap` function of `mendel-core/trees`

`findServerVariationMap` does not have to go thru every single bundle id specified in `.mendel.rc`

@irae 