### PR TITLE
Remove unused devdep from pkg json

### DIFF
--- a/examples/full-example/package.json
+++ b/examples/full-example/package.json
@@ -30,7 +30,6 @@
     "karma-spec-reporter": "0.0.26",
     "mendel": "*",
     "mendel-development-middleware": "*",
-    "mendel-extractify": "*",
     "mendel-manifest-extract-bundles": "*",
     "nodemon": "^1.9.2",
     "react-addons-test-utils": "^0.14.8",


### PR DESCRIPTION
`npm install` returns 404  'mendel-extractify' is not in the npm registry. As far as I know it is not used anymore. We could use this PR to remove it completely from the repo, as well.
