### PR TITLE
A number performance improvements on mendel-middleware and mendel-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 coverage/
 .nyc_output/
 mendel-build/
+build-requirify/

--- a/examples/full-example/app.js
+++ b/examples/full-example/app.js
@@ -6,9 +6,17 @@ var ReactDOMServer = require('react-dom/server');
 var express = require('express');
 var logger = require('morgan');
 var MendelMiddleware = require('mendel-middleware');
+var cache = true;
+
 if (process.env.NODE_ENV !== 'production') {
     MendelMiddleware = require('mendel-development-middleware');
+    cache = false;
 }
+
+if (String(process.env.CACHE) === 'false') {
+    cache = false;
+}
+
 
 var app = express();
 app.use(logger('tiny'));
@@ -20,6 +28,9 @@ app.get('/', function(req, res) {
     .split(',').filter(Boolean);
     var serverRender = req.query.ssr !== 'false' && req.mendel.isSsrReady();
     var optionalMarkup = "";
+
+    // populates req.mendel.variations with validated and sorted variations
+    req.mendel.setVariations(variations);
 
     if (serverRender) {
         // To improve ssr performance, you need to pass
@@ -34,12 +45,12 @@ app.get('/', function(req, res) {
         '<!DOCTYPE html>',
         '<html><head></head><body>',
             '<div id="main">'+optionalMarkup+'</div>',
-            bundle(req, 'vendor', variations),
-            bundle(req, 'main', variations),
+            bundle(req, 'vendor'),
+            bundle(req, 'main'),
             // The full example supports on-demand loading, lazy bundle
             // is only loaded client-side when a button is clicked in the
             // application
-            entryMap(req, 'lazy', variations),
+            entryMap(req, 'lazy'),
         '</body></html>'
     ].join('\n');
 
@@ -47,33 +58,53 @@ app.get('/', function(req, res) {
     res.end();
 });
 
-function bundle(req, bundle, variations) {
-    var url = req.mendel.getURL(bundle, variations);
-    return '<script src="'+url+'"></script>';
+// Simple caching added to example, since very large applications can experience
+// overhead added by mendel hashing bundles.
+// Caching is not part of the middleware itself because large deployments with
+// dozens or hundreds of nodejs processes will prefer distributed caches such as
+// memcached, redis, etc
+var bundleCache = {};
+var entryMapCache = {};
+
+
+function bundle(req, bundle) {
+    var key = bundle + ':' + req.mendel.variations.join(':');
+    if (!cache || !bundleCache[key]) {
+        var url = req.mendel.getURL(bundle);
+        bundleCache[key] = '<script src="'+url+'"></script>';
+    }
+    return bundleCache[key];
 }
 
-function entryMap(req, bundle, variations) {
-    // req.mendel.getBundleEntries contains all bundles as keys and array of
-    // entries that were used and normalized by variations, this allows apps
-    // to create specific logic with their bundles in runtime
-    var bundles = req.mendel.getBundleEntries();
 
-    // In this particular case, entryMap will be used to expose to the client
-    // the URL for bundles based on modules that are "exposed", meaning, after
-    // loading the bundle, you can `require('entryName.js')` for any entry.
-    var entryMapScript =  [
-        '<script>',
-        '   (function(){',
-        '       var nameSpace = "_mendelEntryMap";',
-        '       var url = "'+req.mendel.getURL(bundle, variations)+'";',
-        '       window[nameSpace] = window[nameSpace] || {};',
-        '       ' + bundles[bundle].map(function(entry) {
-                    return 'window[nameSpace]["'+entry+'"] = ' + ' url;';
-                }).join('\n       '),
-        '   })()',
-        '</script>'
-    ];
-    return entryMapScript.join('\n');
+function entryMap(req, bundle) {
+    var key = bundle + ':' + req.mendel.variations.join(':');
+    if (!cache || !entryMapCache[key]) {
+
+        // req.mendel.getBundleEntries contains all bundles as keys and array of
+        // entries that were used and normalized by variations, this allows apps
+        // to create specific logic with their bundles in runtime
+        var bundles = req.mendel.getBundleEntries();
+
+        // In this particular case, entryMap will be used to expose to the client
+        // the URL for bundles based on modules that are "exposed", meaning, after
+        // loading the bundle, you can `require('entryName.js')` for any entry.
+        var entryMapScript =  [
+            '<script>',
+            '   (function(){',
+            '       var nameSpace = "_mendelEntryMap";',
+            '       var url = "'+req.mendel.getURL(bundle)+'";',
+            '       window[nameSpace] = window[nameSpace] || {};',
+            '       ' + bundles[bundle].map(function(entry) {
+                        return 'window[nameSpace]["'+entry+'"] = ' + ' url;';
+                    }).join('\n       '),
+            '   })()',
+            '</script>'
+        ];
+        entryMapCache[key] = entryMapScript.join('\n');
+
+    }
+    return entryMapCache[key];
 }
 
 module.exports = app;

--- a/examples/full-example/app.js
+++ b/examples/full-example/app.js
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV !== 'production') {
     cache = false;
 }
 
-if (String(process.env.CACHE) === 'false') {
+if (String(process.env.MENDEL_CACHE) === 'false') {
     cache = false;
 }
 
@@ -81,9 +81,10 @@ function entryMap(req, bundle) {
     var key = bundle + ':' + req.mendel.variations.join(':');
     if (!cache || !entryMapCache[key]) {
 
-        // req.mendel.getBundleEntries contains all bundles as keys and array of
-        // entries that were used and normalized by variations, this allows apps
-        // to create specific logic with their bundles in runtime
+        // `req.mendel.getBundleEntries` contains all bundles as keys and arrays
+        // of entries that were used (normalized by variations) as values. This
+        // allows apps to create a specific logic with their bundles in the
+        // runtime.
         var bundles = req.mendel.getBundleEntries();
 
         // In this particular case, entryMap will be used to expose to the client

--- a/examples/full-example/app.js
+++ b/examples/full-example/app.js
@@ -35,7 +35,7 @@ app.get('/', function(req, res) {
     if (serverRender) {
         // To improve ssr performance, you need to pass
         // array of bundle ids you only need for ssr rendering
-        var resolver = req.mendel.resolver(['main'], variations);
+        var resolver = req.mendel.resolver(['main']);
         var Main = resolver.require('main.js');
 
         optionalMarkup = ReactDOMServer.renderToString(Main())

--- a/packages/mendel-core/package.json
+++ b/packages/mendel-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Mendel shared dependencies production use",
   "main": "trees.js",
   "scripts": {

--- a/packages/mendel-core/tree-variation-walker-server.js
+++ b/packages/mendel-core/tree-variation-walker-server.js
@@ -4,16 +4,19 @@
    See the accompanying LICENSE file for terms. */
 
 var util = require("util");
+var xtend = require("xtend");
 var MendelVariationWalker = require('./tree-variation-walker');
 
 util.inherits(MendelServerVariationWalker, MendelVariationWalker);
 
-function MendelServerVariationWalker(_lookupChains, _base) {
+function MendelServerVariationWalker(opts) {
     if (!(this instanceof MendelServerVariationWalker)) {
-        return new MendelServerVariationWalker(_lookupChains, _base);
+        return new MendelServerVariationWalker(opts);
     }
 
-    MendelVariationWalker.call(this, _lookupChains, _base);
+    MendelVariationWalker.call(this, xtend({
+        hash: false // This walker doesn't care about deps index nor hashes
+    }, opts));
 
     this._resolveCache = {};
     this._variationMap = {};

--- a/packages/mendel-core/tree-variation-walker-server.js
+++ b/packages/mendel-core/tree-variation-walker-server.js
@@ -4,19 +4,16 @@
    See the accompanying LICENSE file for terms. */
 
 var util = require("util");
-var xtend = require("xtend");
 var MendelVariationWalker = require('./tree-variation-walker');
 
 util.inherits(MendelServerVariationWalker, MendelVariationWalker);
 
-function MendelServerVariationWalker(opts) {
+function MendelServerVariationWalker(_lookupChains, _base) {
     if (!(this instanceof MendelServerVariationWalker)) {
-        return new MendelServerVariationWalker(opts);
+        return new MendelServerVariationWalker(_lookupChains, _base);
     }
 
-    MendelVariationWalker.call(this, xtend({
-        hash: false // This walker doesn't care about deps index nor hashes
-    }, opts));
+    MendelVariationWalker.call(this, _lookupChains, _base, false);
 
     this._resolveCache = {};
     this._variationMap = {};

--- a/packages/mendel-core/tree-variation-walker.js
+++ b/packages/mendel-core/tree-variation-walker.js
@@ -11,14 +11,18 @@ var MendelWalker = require('./tree-walker');
 util.inherits(MendelVariationWalker, MendelWalker);
 module.exports = MendelVariationWalker;
 
-function MendelVariationWalker(_lookupChains, _base) {
+function MendelVariationWalker(opts) {
     if (!(this instanceof MendelVariationWalker)) {
-        return new MendelVariationWalker(_lookupChains, _base);
+        return new MendelVariationWalker(opts);
     }
-    MendelWalker.call(this);
+    MendelWalker.call(this, opts);
 
-    this._lookupChains = _lookupChains;
-    this._base = _base;
+    if (!opts) {
+        opts = {};
+    }
+
+    this._lookupChains = opts.lookupChains;
+    this._base = opts.base;
     this.conflicts = 0;
     this.conflictList = {};
 }

--- a/packages/mendel-core/tree-variation-walker.js
+++ b/packages/mendel-core/tree-variation-walker.js
@@ -11,18 +11,14 @@ var MendelWalker = require('./tree-walker');
 util.inherits(MendelVariationWalker, MendelWalker);
 module.exports = MendelVariationWalker;
 
-function MendelVariationWalker(opts) {
+function MendelVariationWalker(_lookupChains, _base, _hash) {
     if (!(this instanceof MendelVariationWalker)) {
-        return new MendelVariationWalker(opts);
+        return new MendelVariationWalker(_lookupChains, _base, _hash);
     }
-    MendelWalker.call(this, opts);
+    MendelWalker.call(this);
 
-    if (!opts) {
-        opts = {};
-    }
-
-    this._lookupChains = opts.lookupChains;
-    this._base = opts.base;
+    this._lookupChains = _lookupChains;
+    this._base = _base;
     this.conflicts = 0;
     this.conflictList = {};
 }

--- a/packages/mendel-core/tree-walker.js
+++ b/packages/mendel-core/tree-walker.js
@@ -5,13 +5,18 @@
 
 var TreeSerialiser = require('./tree-serialiser');
 
-function MendelWalker() {
+function MendelWalker(opts) {
     if (!(this instanceof MendelWalker)) {
-        return new MendelWalker();
+        return new MendelWalker(opts);
+    }
+    if (!opts) {
+        opts = {};
     }
 
     this.deps = [];
-    this.serialiser = new TreeSerialiser();
+    if (opts.hash !== false) {
+        this.serialiser = new TreeSerialiser();
+    }
 }
 
 MendelWalker.prototype.find = function(module) {
@@ -23,7 +28,9 @@ MendelWalker.prototype.find = function(module) {
     } else {
         var branch = this._resolveBranch(module);
         resolved = branch.resolved;
-        this.serialiser.pushBranch(branch.index);
+        if (this.serialiser) {
+            this.serialiser.pushBranch(branch.index);
+        }
     }
     this.deps[module.index] = resolved;
     this.serialiser.pushFileHash(new Buffer(resolved.sha, 'hex'));
@@ -36,10 +43,13 @@ MendelWalker.prototype._resolveBranch = function() {
 };
 
 MendelWalker.prototype.found = function() {
-    return {
-        deps: this.deps,
-        hash: this.serialiser.result()
+    var found = {
+        deps: this.deps
     };
+    if (this.serialiser) {
+        found.hash = this.serialiser.result();
+    }
+    return found;
 };
 
 module.exports = MendelWalker;

--- a/packages/mendel-core/tree-walker.js
+++ b/packages/mendel-core/tree-walker.js
@@ -5,16 +5,13 @@
 
 var TreeSerialiser = require('./tree-serialiser');
 
-function MendelWalker(opts) {
+function MendelWalker(_lookupChains, _base, _hash) {
     if (!(this instanceof MendelWalker)) {
-        return new MendelWalker(opts);
-    }
-    if (!opts) {
-        opts = {};
+        return new MendelWalker(_lookupChains, _base, _hash);
     }
 
     this.deps = [];
-    if (opts.hash !== false) {
+    if (_hash !== false) {
         this.serialiser = new TreeSerialiser();
     }
 }
@@ -33,7 +30,9 @@ MendelWalker.prototype.find = function(module) {
         }
     }
     this.deps[module.index] = resolved;
-    this.serialiser.pushFileHash(new Buffer(resolved.sha, 'hex'));
+    if (this.serialiser) {
+        this.serialiser.pushFileHash(new Buffer(resolved.sha, 'hex'));
+    }
 
     return resolved;
 };

--- a/packages/mendel-core/trees.js
+++ b/packages/mendel-core/trees.js
@@ -20,8 +20,8 @@ function MendelTrees(opts) {
     var config = parseConfig(opts);
     var variations = parseVariations(config);
     variations.push({
-        'id': config.base || 'base',
-        chain: [config.basetree || 'base']
+        'id': config.base,
+        chain: [config.basetree]
     });
 
     this.config = config;
@@ -66,7 +66,7 @@ MendelTrees.prototype.findTreeForHash = function(bundle, hash) {
 MendelTrees.prototype._loadBundles = function() {
     var self = this;
     this.bundles = {};
-    var confBundles = self.config.bundles || [];
+    var confBundles = self.config.bundles;
     confBundles.forEach(function(bundle) {
         var bundlePath = path.join(self.config.outdir, bundle.manifest);
         try {

--- a/packages/mendel-core/trees.js
+++ b/packages/mendel-core/trees.js
@@ -101,9 +101,6 @@ MendelTrees.prototype._loadBundles = function() {
             throw newError;
         }
     });
-    if (Object.freeze) {
-        deepFreeze(this.bundles);
-    }
 };
 
 MendelTrees.prototype._walkTree = function(bundle, finder) {
@@ -150,17 +147,6 @@ function walk(tree, module, pathFinder) {
         var subdep = tree.bundles[index];
         if (subdep) walk(tree, subdep, pathFinder);
     }
-}
-
-function deepFreeze(obj) {
-  var propNames = Object.getOwnPropertyNames(obj);
-  propNames.forEach(function(name) {
-    var prop = obj[name];
-    if (typeof prop == 'object' && prop !== null)
-      deepFreeze(prop);
-  });
-
-  return Object.freeze(obj);
 }
 
 

--- a/packages/mendel-core/trees.js
+++ b/packages/mendel-core/trees.js
@@ -29,37 +29,19 @@ function MendelTrees(opts) {
     this._loadBundles();
 }
 
-MendelTrees.prototype.findTreeForVariations = function(bundle, variations) {
-    if (typeof variations ==='string') {
-        variations = [variations];
-    }
-
-    var variationsAndChains = this.variationsAndChains(variations);
-    var lookupChains = variationsAndChains.lookupChains;
-    var finder = new MendelVariationWalker({
-        lookupChains: lookupChains,
-        base: this.config.base
-    });
+MendelTrees.prototype.findTreeForVariations = function(bundle, lookupChains) {
+    var finder = new MendelVariationWalker(lookupChains, this.config.base);
 
     this._walkTree(bundle, finder);
 
-    return xtend(variationsAndChains, finder.found());
+    return finder.found();
 };
 
-MendelTrees.prototype.findServerVariationMap = function(bundles, variations) {
-    if (typeof variations ==='string') {
-        variations = [variations];
-    }
-
+MendelTrees.prototype.findServerVariationMap = function(bundles, lookupChains) {
     var self = this;
     var variationMap = {};
     var base = self.config.base;
-    var variationsAndChains = this.variationsAndChains(variations);
-    var lookupChains = variationsAndChains.lookupChains;
-    var finder = new MendelServerVariationWalker({
-        lookupChains: lookupChains,
-        base: base
-    });
+    var finder = new MendelServerVariationWalker(lookupChains, base);
 
     function selectBundles(key) {
         return bundles.indexOf(key) !== -1;

--- a/packages/mendel-development-loader/package.json
+++ b/packages/mendel-development-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development-loader",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Mendel development server side require hook.",
   "main": "loader.js",
   "scripts": {
@@ -19,6 +19,6 @@
   },
   "dependencies": {
     "mendel-development": "^1.1.0",
-    "mendel-loader": "^2.0.0"
+    "mendel-loader": "^2.1.0"
   }
 }

--- a/packages/mendel-development-middleware/index.js
+++ b/packages/mendel-development-middleware/index.js
@@ -98,9 +98,10 @@ function MendelMiddleware(opts) {
         req.mendel.getURL = function(bundle, variations) {
             if (!req.mendel.variations && variations) {
                 console.warn(
-                    'mendel.getURL(bundle, variations) is deprecated. '+
-                    'Please use mendel.setVariations(variations), followed by'+
-                    ' mendel.getURL(bundle).'
+                    '[DEPRECATED] Please replace use of '+
+                    'mendel.getURL(bundle, variations).'+
+                    '\nUse mendel.setVariations(variations) followed by'+
+                    ' mendel.getURL(bundle) instead.'
                 );
                 req.mendel.setVariations(variations);
             }
@@ -111,9 +112,10 @@ function MendelMiddleware(opts) {
         req.mendel.resolver = function(bundles, variations) {
             if (!req.mendel.variations && variations) {
                 console.warn(
-                    'mendel.resolver([bundles], variations) is deprecated. '+
-                    'Please use mendel.setVariations(variations), followed by'+
-                    ' mendel.resolver([bundles]).'
+                    '[DEPRECATED] Please replace use of '+
+                    'mendel.resolver(bundle, variations).'+
+                    '\nUse mendel.setVariations(variations) followed by'+
+                    ' mendel.resolver(bundle) instead.'
                 );
                 req.mendel.setVariations(variations);
             }

--- a/packages/mendel-development-middleware/package.json
+++ b/packages/mendel-development-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development-middleware",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "express middleware for meldel",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "fs-extra": "^0.30.0",
     "mendel-config": "^1.1.1",
     "mendel-development": "^1.1.0",
-    "mendel-development-loader": "^2.0.0",
+    "mendel-development-loader": "^2.1.0",
     "mendel-requirify": "^1.0.6",
     "mendel-treenherit": "^1.0.6",
     "stream-cache": "0.0.2",

--- a/packages/mendel-loader/package.json
+++ b/packages/mendel-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-loader",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Mendel server side require hook.",
   "main": "loader.js",
   "scripts": {

--- a/packages/mendel-loader/resolver.js
+++ b/packages/mendel-loader/resolver.js
@@ -67,6 +67,7 @@ MendelResolver.prototype.require = function (name) {
     if (modExports.__mendel_module__) {
         var mendelFn = modExports;
         var mendelMod = {
+            parent: parent,
             exports: {},
             require: that.require.bind(that)
         };

--- a/packages/mendel-middleware/index.js
+++ b/packages/mendel-middleware/index.js
@@ -52,11 +52,6 @@ function MendelMiddleware(opts) {
                 var varsAndChains = trees.variationsAndChains(variations);
                 req.mendel.variations = varsAndChains.matchingVariations;
                 req.mendel.lookupChains = varsAndChains.lookupChains;
-                if (Object.freeze) {
-                    Object.freeze(req.mendel);
-                    Object.freeze(req.mendel.variations);
-                    Object.freeze(req.mendel.lookupChains);
-                }
             }
             return req.mendel.variations;
         };
@@ -88,7 +83,10 @@ function MendelMiddleware(opts) {
             return getPath({ bundle: bundle, hash: tree.hash });
         };
 
-        req.mendel.resolver = loader.resolver.bind(loader);
+        req.mendel.resolver = function(bundles) {
+            return loader.resolver(bundles, req.mendel.variations);
+        };
+
         req.mendel.isSsrReady = loader.isSsrReady.bind(loader);
 
         // Match bundle route

--- a/packages/mendel-middleware/index.js
+++ b/packages/mendel-middleware/index.js
@@ -63,7 +63,7 @@ function MendelMiddleware(opts) {
 
             if(!req.mendel.bundleCache[bundle]) {
                 var tree = trees.findTreeForVariations(
-                                            bundle, req.mendel.variations);
+                                            bundle, req.mendel.lookupChains);
                 req.mendel.bundleCache[bundle] = tree;
             }
 
@@ -84,7 +84,7 @@ function MendelMiddleware(opts) {
         };
 
         req.mendel.resolver = function(bundles) {
-            return loader.resolver(bundles, req.mendel.variations);
+            return loader.resolver(bundles, req.mendel.lookupChains);
         };
 
         req.mendel.isSsrReady = loader.isSsrReady.bind(loader);

--- a/packages/mendel-middleware/index.js
+++ b/packages/mendel-middleware/index.js
@@ -83,7 +83,15 @@ function MendelMiddleware(opts) {
             return getPath({ bundle: bundle, hash: tree.hash });
         };
 
-        req.mendel.resolver = function(bundles) {
+        req.mendel.resolver = function(bundles, variations) {
+            if (!req.mendel.variations && variations) {
+                console.warn(
+                    'mendel.resolver([bundles], variations) is deprecated. '+
+                    'Please use mendel.setVariations(variations), followed by'+
+                    ' mendel.resolver([bundles]).'
+                );
+                req.mendel.setVariations(variations);
+            }
             return loader.resolver(bundles, req.mendel.lookupChains);
         };
 

--- a/packages/mendel-middleware/index.js
+++ b/packages/mendel-middleware/index.js
@@ -58,7 +58,7 @@ function MendelMiddleware(opts) {
 
         req.mendel.getBundle = function(bundle) {
             if (!req.mendel.variations) {
-                throw new Error('Please, call req.mendel.setVariations first');
+                throw new Error('Please call req.mendel.setVariations first');
             }
 
             if(!req.mendel.bundleCache[bundle]) {
@@ -73,9 +73,10 @@ function MendelMiddleware(opts) {
         req.mendel.getURL = function(bundle, variations) {
             if (!req.mendel.variations && variations) {
                 console.warn(
-                    'mendel.getURL(bundle, variations) is deprecated. '+
-                    'Please use mendel.setVariations(variations), followed by'+
-                    ' mendel.getURL(bundle).'
+                    '[DEPRECATED] Please replace use of '+
+                    'mendel.getURL(bundle, variations).'+
+                    '\nUse mendel.setVariations(variations) followed by'+
+                    ' mendel.getURL(bundle) instead.'
                 );
                 req.mendel.setVariations(variations);
             }
@@ -86,9 +87,10 @@ function MendelMiddleware(opts) {
         req.mendel.resolver = function(bundles, variations) {
             if (!req.mendel.variations && variations) {
                 console.warn(
-                    'mendel.resolver([bundles], variations) is deprecated. '+
-                    'Please use mendel.setVariations(variations), followed by'+
-                    ' mendel.resolver([bundles]).'
+                    '[DEPRECATED] Please replace use of '+
+                    'mendel.resolver(bundle, variations).'+
+                    '\nUse mendel.setVariations(variations) followed by'+
+                    ' mendel.resolver(bundle) instead.'
                 );
                 req.mendel.setVariations(variations);
             }

--- a/packages/mendel-middleware/package.json
+++ b/packages/mendel-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-middleware",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Mendel Middleware that uses generated manifests to output multilayer resolution of isomorphic applications.",
   "main": "index.js",
   "scripts": {
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "browser-pack": "^6.0.1",
-    "mendel-core": "^2.0.0",
-    "mendel-loader": "^2.0.0",
+    "mendel-core": "^2.1.0",
+    "mendel-loader": "^2.1.0",
     "path-to-regexp": "^1.2.1"
   }
 }

--- a/packages/mendel-requirify/index.js
+++ b/packages/mendel-requirify/index.js
@@ -9,7 +9,7 @@ var mendelRequireTransform = require('mendel-development/require-transform');
 var variationMatches = require('mendel-development/variation-matches');
 
 function requirify(b, opts) {
-    var outdir = opts.outdir || path.join(process.cwd(), 'mendel-requirify');
+    var outdir = opts.outdir || path.join(process.cwd(), 'build-requirify');
     var dirs = opts.dirs || (b.variation && b.variation.chain) || [];
 
     function addHooks() {

--- a/packages/mendel-requirify/package.json
+++ b/packages/mendel-requirify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-requirify",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Write individual mendel-requirified dep files from the mendel browserify pipeline.",
   "main": "index.js",
   "scripts": {

--- a/test/app-samples/1/.mendelrc
+++ b/test/app-samples/1/.mendelrc
@@ -1,6 +1,7 @@
 
 # relative to basedir, defaults to "build"
 outdir: build
+serveroutdir: ../build-requirify
 
 base: app
 basetree: app

--- a/test/app-samples/1/run.sh
+++ b/test/app-samples/1/run.sh
@@ -3,5 +3,5 @@
 mkdir -p build
 
 browserify app/index.js -p ../../../packages/mendel-browserify \
+    -p  ../../../packages/mendel-requirify \
     -o build/app.js
-

--- a/test/mendel-loader.js
+++ b/test/mendel-loader.js
@@ -66,7 +66,7 @@ test('mendel-loader-server', function(t){
             }];
 
             inputs.forEach(function (i) {
-                var resolver = loader.resolver(['app'], i.variations);
+                var resolver = loader.resolver(['app'], tree.variationsAndChains(i.variations).lookupChains);
                 var variation = i.variations.join(',');
 
                 var someNumber = resolver.require('some-number.js');
@@ -105,7 +105,7 @@ test('mendel-loader-server-syntax-error', function(t){
         });
         // test without 'new'
         var loader = Loader(tree);
-        var resolver = loader.resolver(['app'], ['test_B']);
+        var resolver = loader.resolver(['app'], tree.variationsAndChains(['test_B']).lookupChains);
 
         var invalidFile = path.join(srcDir, 'app/syntax-error.js');
         t.throws(function() {

--- a/test/mendel-middleware.js
+++ b/test/mendel-middleware.js
@@ -88,7 +88,7 @@ tap.test('getURL still works with variations', function(t){
         t.match(json, {
             appBundle: appBundle
         });
-        t.contains(msg, 'is deprecated', 'getURL show deprecated msg');
+        t.contains(msg, '[DEPRECATED]', 'getURL show deprecated msg');
     });
 });
 
@@ -135,7 +135,7 @@ tap.test('resolver still works with variations', function(t){
 
         t.match(response, { statusCode: 200 }, 'serves javascript');
         t.match(json.result, -2, 'resolver with correct content');
-        t.contains(msg, 'is deprecated', 'resolver show deprecated message');
+        t.contains(msg, '[DEPRECATED]', 'resolver show deprecated message');
     });
 });
 
@@ -166,7 +166,7 @@ tap.test('throws on incorrect use', function(t){
             statusCode: 500
         }, 'serves javascript');
         t.match(json, {
-            error: 'Please, call req.mendel.setVariations first'
+            error: 'Please call req.mendel.setVariations first'
         }, 'throws error when called in wrong order');
     });
 });

--- a/test/mendel-middleware.js
+++ b/test/mendel-middleware.js
@@ -1,0 +1,212 @@
+/* Copyright 2015, Yahoo Inc.
+   Copyrights licensed under the MIT License.
+   See the accompanying LICENSE file for terms. */
+
+var tap = require('tap');
+var express = require('express');
+var request = require('request');
+var path = require('path');
+var async = require('async');
+var exec = require('child_process').exec;
+
+var appPath = path.join(__dirname, './app-samples/1/');
+var host = 'http://localhost:1337';
+var appBundle = '/mendel/bWVuZGVsAQEA_wUAbddjTtQONPBGmb28yZdfmFFI58c/app.js';
+
+var sut = require('../packages/mendel-middleware');
+
+var app = express();
+app.use(sut({
+    basedir: appPath
+}));
+
+var server = app.listen('1337');
+tap.tearDown(function() {
+    server.close(process.exit);
+});
+
+tap.test('run build first', function (t) {
+    t.plan(1);
+
+    exec('./run.sh', { cwd: appPath }, function(error) {
+        if (error) return t.bailout('should create manifest but failed', error);
+        t.pass();
+    });
+});
+
+app.get('/getURL_testA', function(req, res) {
+    req.mendel.setVariations(['test_A']);
+    // this lines force that only the first setVariations is accounted for
+    // also increase coverage meaninfully
+    req.mendel.setVariations(['test_C']);
+    res.json({
+        appBundle: req.mendel.getURL('app')
+    });
+});
+
+tap.test('getURL returns correct hash', function(t){
+    t.plan(2);
+
+    request({
+        url: host+'/getURL_testA',
+        json:true
+    }, function(error, response, json) {
+        if (error) t.bailout(error);
+
+        t.match(response, {
+            statusCode: 200
+        }, 'getURL without errors');
+        t.match(json, {
+            appBundle: appBundle
+        }, 'getURL correct hash');
+    });
+});
+
+app.get('/getURLDeprecated', function(req, res) {
+    res.json({
+        appBundle: req.mendel.getURL('app', ['test_A'])
+    });
+});
+
+tap.test('getURL still works with variations', function(t){
+    t.plan(3);
+
+    var old = console.warn;
+    var msg = null;
+    console.warn = function(a) {msg = a;};
+
+    request({
+        url: host+'/getURLDeprecated',
+        json:true
+    }, function(error, response, json) {
+        console.warn = old;
+        if (error) t.bailout(error);
+
+        t.match(response, {
+            statusCode: 200
+        }, 'serves javascript');
+        t.match(json, {
+            appBundle: appBundle
+        });
+        t.contains(msg, 'is deprecated', 'getURL show deprecated msg');
+    });
+});
+
+app.get('/resolver_testA', function(req, res) {
+    req.mendel.setVariations(['test_A']);
+    res.json({
+        result: req.mendel.resolver(['app']).require('index.js')()
+    });
+});
+
+tap.test('resolver require gets correct code', function(t){
+    t.plan(2);
+
+    request({
+        url: host+'/resolver_testA',
+        json: true
+    }, function(error, response, json) {
+        if (error) t.bailout(error);
+
+        t.match(response, { statusCode: 200 }, 'resolver without errors');
+        t.match(json.result, -2, 'resolver with correct content');
+    });
+});
+
+app.get('/resolverDeprecated', function(req, res) {
+    res.json({
+        result: req.mendel.resolver(['app'], ['test_A']).require('index.js')()
+    });
+});
+
+tap.test('resolver still works with variations', function(t){
+    t.plan(3);
+
+    var old = console.warn;
+    var msg = null;
+    console.warn = function(a) {msg = a;};
+
+    request({
+        url: host+'/resolverDeprecated',
+        json:true
+    }, function(error, response, json) {
+        console.warn = old;
+        if (error) t.bailout(error);
+
+        t.match(response, { statusCode: 200 }, 'serves javascript');
+        t.match(json.result, -2, 'resolver with correct content');
+        t.contains(msg, 'is deprecated', 'resolver show deprecated message');
+    });
+});
+
+
+app.get('/getBundleIncorrect', function(req, res) {
+    try {
+        req.mendel.getBundle('app'); // this line throws
+    } catch (e) {
+        res.status(500).json({
+            error: e.message
+        });
+        return;
+    }
+    res.json({unreachable: 'prop'});
+});
+
+
+tap.test('throws on incorrect use', function(t){
+    t.plan(2);
+
+    request({
+        url: host+'/getBundleIncorrect',
+        json:true
+    }, function(error, response, json) {
+        if (error) t.bailout(error);
+
+        t.match(response, {
+            statusCode: 500
+        }, 'serves javascript');
+        t.match(json, {
+            error: 'Please, call req.mendel.setVariations first'
+        }, 'throws error when called in wrong order');
+    });
+});
+
+app.get('/getBundleCacheLoop', function(req, res) {
+    var fail = false;
+    var timer = setTimeout(function() {
+        fail = true;
+        res.sendStatus(500);
+    }, 100);
+
+    req.mendel.setVariations(['test_A']);
+
+    function doIt(done) {
+        req.mendel.getBundle('app');
+        done();
+    }
+
+    var calls = [doIt];
+    for (var i = 0; i < 10000; i++) {
+        calls.push(doIt);
+    }
+    async.series(calls, function() {
+        if (!fail) {
+            clearTimeout(timer);
+            res.sendStatus(200);
+        }
+    });
+});
+
+
+tap.test('getBundle cached per request', function(t) {
+    t.plan(1);
+
+    request({
+        url: host+'/getBundleCacheLoop',
+        json:true
+    }, function(error, response) {
+        if (error) t.bailout(error);
+
+        t.equal(response.statusCode, 200, 'looks cached based on timer');
+    });
+});

--- a/test/mendel-requirify.js
+++ b/test/mendel-requirify.js
@@ -15,7 +15,7 @@ var requireTransform = require('../packages/mendel-development/require-transform
 var srcDir = path.resolve(__dirname, './app-samples/1');
 
 temp.track();
-var buildDir = temp.mkdirSync('mendel-requirify');
+var buildDir = temp.mkdirSync('build-requirify');
 
 var entry = 'app/number-list.js';
 var variationDirs = ['test_A', 'app'];
@@ -74,7 +74,7 @@ test('mendel-requirify', function (t) {
 });
 
 test('mendel-requirify-defaults', function (t) {
-    var outDir = path.join(process.cwd(), 'mendel-requirify');
+    var outDir = path.join(process.cwd(), 'build-requirify');
     var outFile = path.join(outDir, entry);
 
     run(t, null, outFile, function (t) {

--- a/test/tree-variation-walker-server.js
+++ b/test/tree-variation-walker-server.js
@@ -19,19 +19,13 @@ var stub1 = {
     ]
 };
 
-var walker = new MendelServerVariationWalker({
-    lookupChains: [['a'],['special']],
-    base: 'special'
-});
+var walker = new MendelServerVariationWalker([['a'],['special']], 'special');
 walker.find(stub1);
 t.same(walker.found(),
     { first: 'a' },
     'variation map');
 
-walker = new MendelServerVariationWalker({
-    lookupChains: [['special']],
-    base: 'special'
-});
+walker = new MendelServerVariationWalker([['special']], 'special');
 walker.find(stub1);
 
 t.same(walker.found(), {

--- a/test/tree-variation-walker-server.js
+++ b/test/tree-variation-walker-server.js
@@ -19,13 +19,19 @@ var stub1 = {
     ]
 };
 
-var walker = new MendelServerVariationWalker([['a'],['special']], 'special');
+var walker = new MendelServerVariationWalker({
+    lookupChains: [['a'],['special']],
+    base: 'special'
+});
 walker.find(stub1);
 t.same(walker.found(),
     { first: 'a' },
     'variation map');
 
-walker = new MendelServerVariationWalker([['special']], 'special');
+walker = new MendelServerVariationWalker({
+    lookupChains: [['special']],
+    base: 'special'
+});
 walker.find(stub1);
 
 t.same(walker.found(), {

--- a/test/tree-variation-walker-server.js
+++ b/test/tree-variation-walker-server.js
@@ -19,7 +19,7 @@ var stub1 = {
     ]
 };
 
-var walker = new MendelServerVariationWalker([['a'],['special']], 'special');
+var walker = MendelServerVariationWalker([['a'],['special']], 'special');
 walker.find(stub1);
 t.same(walker.found(),
     { first: 'a' },

--- a/test/tree-variation-walker.js
+++ b/test/tree-variation-walker.js
@@ -15,7 +15,7 @@ var stub1 = {
     data: [{id:'a', sha:'ba'},{id:'b'},{id:'special'}]
 };
 
-var walker = new MendelVariationWalker([['a'],['special']], 'special');
+var walker = MendelVariationWalker([['a'],['special']], 'special');
 var ret = walker._resolveBranch(stub1);
 
 t.match(ret, {index:0, resolved:{id:'a'}},

--- a/test/tree-variation-walker.js
+++ b/test/tree-variation-walker.js
@@ -15,7 +15,10 @@ var stub1 = {
     data: [{id:'a', sha:'ba'},{id:'b'},{id:'special'}]
 };
 
-var walker = new MendelVariationWalker([['a'],['special']], 'special');
+var walker = new MendelVariationWalker({
+    lookupChains: [['a'],['special']],
+    base: 'special'
+});
 var ret = walker._resolveBranch(stub1);
 
 t.match(ret, {index:0, resolved:{id:'a'}},
@@ -24,7 +27,10 @@ t.match(ret, {index:0, resolved:{id:'a'}},
 t.match(walker.conflicts, 0,
     'no conflicts with base');
 
-walker = new MendelVariationWalker([['nope'], ['b'],['special']], 'special');
+walker = new MendelVariationWalker({
+    lookupChains: [['nope'], ['b'],['special']],
+    base: 'special'
+});
 ret = walker._resolveBranch(stub1);
 
 t.match(ret, {index:1, resolved:{id:'b'}},
@@ -33,13 +39,19 @@ t.match(ret, {index:1, resolved:{id:'b'}},
 t.equals(walker.conflicts, 0,
     'no conflicts with base');
 
-walker = new MendelVariationWalker([['a', 'b'],['special']], 'special');
+walker = new MendelVariationWalker({
+    lookupChains: [['a', 'b'],['special']],
+    base: 'special'
+});
 ret = walker._resolveBranch(stub1);
 
 t.equals(walker.conflicts, 0,
     "Two variations on the same level don't conflict");
 
-walker = new MendelVariationWalker([['a'], ['b'],['special']], 'special');
+walker = new MendelVariationWalker({
+    lookupChains: [['a'], ['b'],['special']],
+    base: 'special'
+});
 ret = walker.find(stub1);
 
 t.equals(walker.conflicts, 1,

--- a/test/tree-variation-walker.js
+++ b/test/tree-variation-walker.js
@@ -15,10 +15,7 @@ var stub1 = {
     data: [{id:'a', sha:'ba'},{id:'b'},{id:'special'}]
 };
 
-var walker = new MendelVariationWalker({
-    lookupChains: [['a'],['special']],
-    base: 'special'
-});
+var walker = new MendelVariationWalker([['a'],['special']], 'special');
 var ret = walker._resolveBranch(stub1);
 
 t.match(ret, {index:0, resolved:{id:'a'}},
@@ -27,10 +24,7 @@ t.match(ret, {index:0, resolved:{id:'a'}},
 t.match(walker.conflicts, 0,
     'no conflicts with base');
 
-walker = new MendelVariationWalker({
-    lookupChains: [['nope'], ['b'],['special']],
-    base: 'special'
-});
+walker = new MendelVariationWalker([['nope'], ['b'],['special']], 'special');
 ret = walker._resolveBranch(stub1);
 
 t.match(ret, {index:1, resolved:{id:'b'}},
@@ -39,19 +33,13 @@ t.match(ret, {index:1, resolved:{id:'b'}},
 t.equals(walker.conflicts, 0,
     'no conflicts with base');
 
-walker = new MendelVariationWalker({
-    lookupChains: [['a', 'b'],['special']],
-    base: 'special'
-});
+walker = new MendelVariationWalker([['a', 'b'],['special']], 'special');
 ret = walker._resolveBranch(stub1);
 
 t.equals(walker.conflicts, 0,
     "Two variations on the same level don't conflict");
 
-walker = new MendelVariationWalker({
-    lookupChains: [['a'], ['b'],['special']],
-    base: 'special'
-});
+walker = new MendelVariationWalker([['a'], ['b'],['special']], 'special');
 ret = walker.find(stub1);
 
 t.equals(walker.conflicts, 1,

--- a/test/trees.js
+++ b/test/trees.js
@@ -57,37 +57,37 @@ test('MendelTrees private methods', function (t) {
     }];
 
     t.equal(
-        trees._buildLookupChains([]).length,
+        trees._variationsAndChains([]).lookupChains.length,
         1,
         'returns base if empty input'
     );
     t.equal(
-        trees._buildLookupChains(['a']).length,
+        trees._variationsAndChains(['a']).lookupChains.length,
         2,
         'returns variation and base'
     );
     t.match(
-        trees._buildLookupChains(['c'])[0],
+        trees._variationsAndChains(['c']).lookupChains[0],
         ['c-chain', 'b-chain'],
         "valid chains don't contain base"
     );
     t.equal(
-        trees._buildLookupChains(['a-chain']).length,
+        trees._variationsAndChains(['a-chain']).lookupChains.length,
         1,
         'find variations, not chains'
     );
     t.equal(
-        trees._buildLookupChains(['a', 'b']).length,
+        trees._variationsAndChains(['a', 'b']).lookupChains.length,
         3,
         'returns multiple variations'
     );
     t.matches(
-        JSON.stringify(trees._buildLookupChains(['a', 'b'])),
-        JSON.stringify(trees._buildLookupChains(['b', 'a'])),
+        JSON.stringify(trees._variationsAndChains(['a', 'b']).lookupChains),
+        JSON.stringify(trees._variationsAndChains(['b', 'a']).lookupChains),
         'order is based on configuration, not input'
     );
     t.matches(
-        JSON.stringify(trees._buildLookupChains(['c', 'b'])),
+        JSON.stringify(trees._variationsAndChains(['c', 'b']).lookupChains),
         JSON.stringify([['b-chain'], ['c-chain', 'b-chain'], ['base-chain']]),
         'correct full output, with only chains'
     );

--- a/test/trees.js
+++ b/test/trees.js
@@ -57,37 +57,37 @@ test('MendelTrees private methods', function (t) {
     }];
 
     t.equal(
-        trees._variationsAndChains([]).lookupChains.length,
+        trees.variationsAndChains([]).lookupChains.length,
         1,
         'returns base if empty input'
     );
     t.equal(
-        trees._variationsAndChains(['a']).lookupChains.length,
+        trees.variationsAndChains(['a']).lookupChains.length,
         2,
         'returns variation and base'
     );
     t.match(
-        trees._variationsAndChains(['c']).lookupChains[0],
+        trees.variationsAndChains(['c']).lookupChains[0],
         ['c-chain', 'b-chain'],
         "valid chains don't contain base"
     );
     t.equal(
-        trees._variationsAndChains(['a-chain']).lookupChains.length,
+        trees.variationsAndChains(['a-chain']).lookupChains.length,
         1,
         'find variations, not chains'
     );
     t.equal(
-        trees._variationsAndChains(['a', 'b']).lookupChains.length,
+        trees.variationsAndChains(['a', 'b']).lookupChains.length,
         3,
         'returns multiple variations'
     );
     t.matches(
-        JSON.stringify(trees._variationsAndChains(['a', 'b']).lookupChains),
-        JSON.stringify(trees._variationsAndChains(['b', 'a']).lookupChains),
+        JSON.stringify(trees.variationsAndChains(['a', 'b']).lookupChains),
+        JSON.stringify(trees.variationsAndChains(['b', 'a']).lookupChains),
         'order is based on configuration, not input'
     );
     t.matches(
-        JSON.stringify(trees._variationsAndChains(['c', 'b']).lookupChains),
+        JSON.stringify(trees.variationsAndChains(['c', 'b']).lookupChains),
         JSON.stringify([['b-chain'], ['c-chain', 'b-chain'], ['base-chain']]),
         'correct full output, with only chains'
     );
@@ -137,8 +137,8 @@ test('MendelTrees valid manifest runtime', function (t) {
         t.equal(variationCount, 4, 'loads manifest');
         t.equal(trees.variations[variationCount-1].id, 'app', 'includes base');
 
-        var result_1 = trees.findTreeForVariations('app', 'test_A');
-        var result_2 = trees.findTreeForVariations('app', ['test_A', 'test_B']);
+        var result_1 = trees.findTreeForVariations('app', trees.variationsAndChains(['test_A']).lookupChains);
+        var result_2 = trees.findTreeForVariations('app', trees.variationsAndChains(['test_A', 'test_B']).lookupChains);
 
         t.match(result_1, {deps:[]},
             'Finds one variation with string input');
@@ -152,10 +152,10 @@ test('MendelTrees valid manifest runtime', function (t) {
         t.match(result_1, decoded,
             'retrieves same tree from hahs');
 
-        var map_1 = trees.findServerVariationMap(['app'], 'test_A');
-        var map_2 = trees.findServerVariationMap(['app'], ['test_A', 'test_B']);
-        var map_3 = trees.findServerVariationMap(['foo'], 'test_A');
-        var map_4 = trees.findServerVariationMap([], 'test_A');
+        var map_1 = trees.findServerVariationMap(['app'], trees.variationsAndChains(['test_A']).lookupChains);
+        var map_2 = trees.findServerVariationMap(['app'], trees.variationsAndChains(['test_A', 'test_B']).lookupChains);
+        var map_3 = trees.findServerVariationMap(['foo'], trees.variationsAndChains(['test_A']).lookupChains);
+        var map_4 = trees.findServerVariationMap([], trees.variationsAndChains(['test_A']).lookupChains);
 
         t.match(map_1, {
             'index.js': 'app',


### PR DESCRIPTION
  * Mendel Core updated ~~so server resolver don't hash tree for no reason~~ reducing memory allocation and "pushing" sha1 -- sha was never actually computed in the first place, good job @gomezd -- What I did removes just a tiny bit, what David did was the bulk of it already.
  * Mendel Core new public method variationsAndChains
  * Mendel Middleware new public method.setVariations()
  * Mendel Middleware new public method .getBundle()
  * Mendel Middleware .getURL() changed so variations is deprecated

With those changes, Mendel Core is now out of the box more performant, maybe the last chages with resolver receiving a bundles array might be even obsolete. Benchmark required to confirm.

Mendel Middleware new methods are intended for better caching by two improvements:

  1. By requiring per-request `setVariations` we can now assure transparently that each bundle only computes the hash once.
  2. By exposing `req.mendel.setVariations()` or directly through `req.mendel.variations` apps have a way of generating consistent and efficient hash that won't duplicate or cache extraneous keys based on "input variations", instead relying on "resolved variations".
  3. New method `req.mendel.getBundle()` allow apps to create powerfull introspection APIs or even better custom debugging tools, this method will also be used by Mendel 2.0 resolver to avoid extra traversal of bundles, so we are commiting to this API upfront.

Missing for future commits before merging this changes:

 - [x] more tests
 - [x] mendel-development-middleware compatible API changes
 - [x] bump package.json in all affected modules


After some internal tests, Julien Lecomte pointed out that the first version of this PR without caching was slightly worst than master.

So first, I added a small bash script on master (to have a baseline) and started tweaking. Anyone can run the script against the full example:

    $ ./bench.sh

I also added a param to full example to avoid caching if desired:

    $ NODE_ENV=production CACHE=false node .

I did some investigation and here are the two optimizations I did:

  1. I found out that `Object.freeze`, even on a per process based was slowing down the implementation too much. This means traversing a frozen Object is more expensive than traversing a regular object.
  2. Some extra tweaks to call some sub-routines less often and use primitive params instead of objects.

Results (each test is 1k iterations, I run each branch 5 times and picked the best result of each):

```
Percentage of the requests served within a certain time (ms)
master        | PR-no-cache   | PR-with-chache
              |               |
  50%      7  |   50%      7  |   50%      2
  66%      8  |   66%      7  |   66%      2
  75%      8  |   75%      8  |   75%      2
  80%      8  |   80%      8  |   80%      2
  90%      8  |   90%      8  |   90%      2
  95%      9  |   95%      9  |   95%      2
  98%     11  |   98%     11  |   98%      3
  99%     13  |   99%     13  |   99%      7
 100%     14  |  100%     15  |  100%      8
              |               |
 mean  7.773  |  mean  7.575  |  mean  2.044 
```

In general this PR is an improvement, but for some reason about 0.1% of requests are 1ms slower. I suspect this is when server is under super heavy load and GC kicks in. I won't investigate further since start entering the realm of over-optimization.