### PR TITLE
Prevent publishing unimportant file to the public package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+docs
+test
+examples
+scripts
+packages


### PR DESCRIPTION
Some files can be omitted out of the public package.

```
./node_modules/mendel
├── LICENSE
├── Readme.md
├── VERSION
├── bin
│   ├── index.js
│   ├── linkall.js
│   └── post-process-manifest.js
├── docs
│   ├── Design.mdown
│   ├── Tests.mdown
│   ├── design_0.png
│   ├── design_1.png
│   └── design_2.png
├── examples
│   ├── Readme.mdown
│   └── full-example
├── package.json
├── packages
│   ├── mendel-browserify
│   ├── mendel-config
│   ├── mendel-core
│   ├── mendel-development
│   ├── mendel-development-loader
│   ├── mendel-development-middleware
│   ├── mendel-extractify
│   ├── mendel-loader
│   ├── mendel-manifest-extract-bundles
│   ├── mendel-middleware
│   ├── mendel-requirify
│   └── mendel-treenherit
└── test
    ├── app-samples
    ├── config-samples
    ├── config.js
    ├── manifest-extract.js
    ├── manifest-samples
    ├── mendel-browserify.js
    ├── mendel-loader.js
    ├── mendel-requirify.js
    ├── post-process-manifest.js
    ├── proxy.js
    ├── require-transform.js
    ├── resolve-dirs.js
    ├── tree-deserializer.js
    ├── tree-hash-walker.js
    ├── tree-serializer.js
    ├── tree-variation-walker-server.js
    ├── tree-variation-walker.js
    ├── tree-walker.js
    ├── trees.js
    ├── variation-samples
    └── variations.js
```
