### PR TITLE
Short ID and exposes for privacy and compression improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {},
   "devDependencies": {
     "async": "^2.1.2",
+    "browserify": "^13.1.1",
     "eslint": "^2.3.0",
     "eslint-cli": "^1.1.0",
     "eslint-plugin-react": "^5.2.2",

--- a/packages/mendel-browserify/package.json
+++ b/packages/mendel-browserify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-browserify",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Browserify plugin for creating bundle A/B test and other variations based on mendel tree merge model. Created for mendel.",
   "main": "index.js",
   "scripts": {
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "defined": "^1.0.0",
-    "mendel-config": "^1.1.0",
-    "mendel-development": "^1.1.0",
+    "mendel-config": "^1.1.1",
+    "mendel-development": "^1.1.1",
     "mendel-treenherit": "^1.0.6",
     "mkdirp": "^0.5.1",
     "shasum": "^1.0.2",

--- a/packages/mendel-cli/mendel-browserify-runner.js
+++ b/packages/mendel-cli/mendel-browserify-runner.js
@@ -49,13 +49,11 @@ module.exports = function(rawConfig, options) {
     }
 
     if (Array.isArray(options.variations)) {
-        console.log(options.variations);
         var old = mendelConfig.variations;
         mendelConfig.variations = {};
         options.variations.forEach(function(id) {
             mendelConfig.variations[id] = old[id];
         });
-        console.log(mendelConfig.variations);
     }
 
     bundles.forEach(function(bundle) {

--- a/packages/mendel-cli/package.json
+++ b/packages/mendel-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Mendel command line utility",
   "bin": {
     "mendel": "cli.js"
@@ -21,9 +21,9 @@
     "async": "^1.5.2",
     "browserify": "^13.0.0",
     "commander": "^2.9.0",
-    "mendel-browserify": "^1.1.0",
-    "mendel-config": "^1.1.0",
-    "mendel-development": "^1.1.0",
+    "mendel-browserify": "^1.1.1",
+    "mendel-config": "^1.1.1",
+    "mendel-development": "^1.1.1",
     "mendel-requirify": "^1.0.7",
     "mkdirp": "^0.5.1",
     "xtend": "^4.0.1"

--- a/packages/mendel-development/package.json
+++ b/packages/mendel-development/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Mendel shared dependencies for build and development",
   "main": "index.js",
   "scripts": {

--- a/scripts/linkall.js
+++ b/scripts/linkall.js
@@ -11,7 +11,7 @@ var packagesdir = path.join(__dirname, '../packages');
 var examplesdir = path.join(__dirname, '../examples');
 var rootdir = path.join(__dirname, '..');
 
-npm(['install', 'async'], rootdir, function() {
+npm(['install'], rootdir, function() {
     var async = require('async');
     var linkedModules = [];
     var linkedDeps = {};

--- a/test/mendel-browserify.js
+++ b/test/mendel-browserify.js
@@ -5,7 +5,7 @@
 var path = require('path');
 var mkdirp = require('mkdirp');
 var test = require('tap').test;
-var mendelPlugin = require('mendel-browserify');
+var mendelPlugin = require('../packages/mendel-browserify');
 
 var appPath = path.resolve(__dirname, 'app-samples/1/');
 var appBuild = path.join(appPath, 'build');


### PR DESCRIPTION
In some cases, full path was exposed on module names, specially if you use mendel-manifest-extract-bundles on a bundle with node_modules inside of it.

This fixes this by changing both ids, expose and deps to remove:
1. Basedir
2. Anything before first "node_modules" string on path

In most cases both are the same, but since plugins can include shims on their source code (like browserify shims) checking for the first occurrence of node_modules improves the path normalization.