### PR TITLE
Refactor on the Watch+FS and analytics

### DIFF
--- a/packages/mendel-pipeline/package.json
+++ b/packages/mendel-pipeline/package.json
@@ -22,8 +22,7 @@
     "mendel-deps": "*",
     "mendel-resolver": "^1.0.0",
     "pretty-ms": "^2.1.0",
-    "resolve": "^1.1.7",
-    "text-table": "^0.2.0"
+    "resolve": "^1.1.7"
   },
   "devDependencies": {
     "eslint": "^3.7.1",

--- a/packages/mendel-pipeline/src/cache/index.js
+++ b/packages/mendel-pipeline/src/cache/index.js
@@ -1,13 +1,12 @@
 const path = require('path');
 
 class Entry {
-    constructor(id, rawSource) {
+    constructor(id) {
         this.id = id;
         this.normalizedId;
         this.type;
         this.effectiveExt = path.extname(id);
         this.sourceVersions = new Map();
-        this.sourceVersions.set('raw', rawSource);
         this.dependents = [];
         this.dependencies = new Map();
         this.dependenciesUpToDate = false;
@@ -116,8 +115,8 @@ class MendelCache {
         return 'still working on it';
     }
 
-    addEntry(id, rawSource) {
-        this._store.set(id, new Entry(id, rawSource));
+    addEntry(id) {
+        this._store.set(id, new Entry(id));
         const entry = this._store.get(id);
         entry.variation = this.getVariation(id);
         entry.normalizedId = this.getNormalizedId(id);

--- a/packages/mendel-pipeline/src/fs-reader/index.js
+++ b/packages/mendel-pipeline/src/fs-reader/index.js
@@ -1,0 +1,33 @@
+const EventEmitter = require('events').EventEmitter;
+const path = require('path');
+const fs = require('fs');
+
+class FileReader extends EventEmitter {
+    constructor({registry}, {types, cwd}) {
+        super();
+
+        this.cwd = cwd;
+        this.registry = registry;
+        this.sourceExt = new Set();
+        Object.keys(types)
+        .filter(typeName => !types[typeName].isBinary)
+        .forEach(typeName => types[typeName].extensions.forEach(ext => this.sourceExt.add(ext)));
+
+        registry.on('entryAdded', this.read.bind(this));
+    }
+
+    read(entry) {
+        const filePath = entry.id;
+        const encoding = this.sourceExt.has(path.extname(filePath)) ? 'utf8' : 'binary';
+
+        fs.readFile(path.resolve(this.cwd, filePath), encoding, (err, source) => {
+            if (err) {
+                // TODO handle the error
+            }
+
+            this.registry.addRawSource(filePath, source);
+        });
+    }
+}
+
+module.exports = FileReader;

--- a/packages/mendel-pipeline/src/fs-reader/index.js
+++ b/packages/mendel-pipeline/src/fs-reader/index.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events').EventEmitter;
 const path = require('path');
 const fs = require('fs');
+const analytics = require('../helpers/analytics/analytics')('fs');
 
 class FileReader extends EventEmitter {
     constructor({registry}, {types, cwd}) {
@@ -20,11 +21,13 @@ class FileReader extends EventEmitter {
         const filePath = entry.id;
         const encoding = this.sourceExt.has(path.extname(filePath)) ? 'utf8' : 'binary';
 
+        analytics.tic('read');
         fs.readFile(path.resolve(this.cwd, filePath), encoding, (err, source) => {
             if (err) {
                 // TODO handle the error
             }
 
+            analytics.toc('read');
             this.registry.addRawSource(filePath, source);
         });
     }

--- a/packages/mendel-pipeline/src/helpers/analytics/cli-printer.js
+++ b/packages/mendel-pipeline/src/helpers/analytics/cli-printer.js
@@ -1,14 +1,7 @@
 const BasePrinter = require('./printer');
 const chalk = require('chalk');
-const table = require('text-table');
 const prettyMs = require('pretty-ms');
 const figure = require('figures');
-
-function println(text, indentation) {
-    const indent = new Array(indentation + 1).join('  ');
-
-    console.log(indent + text.split('\n').join('\n' + indent));
-}
 
 function getBarText(percent, maxBarSize) {
     const barNumber = Math.max(Math.ceil(percent / 100 * maxBarSize), 1);
@@ -54,7 +47,7 @@ class CliPrinter extends BasePrinter {
             return Object.keys(subData).forEach(groupedName => {
                 const dataPart = subData[groupedName];
 
-                println(chalk.underline(groupedName), indentation);
+                console.log(new Array(indentation + 1).join('  ') + chalk.underline(groupedName));
                 this._print(dataPart, dimensions.slice(1), indentation + 1);
             });
         }
@@ -62,40 +55,51 @@ class CliPrinter extends BasePrinter {
         // Group/aggregate the data
         const points = Object.keys(subData).map(groupedName => {
             const dataPart = subData[groupedName];
+
+            // Special case: make the labels pretty!
+            if (indentation === 0 && dimensions.length === 1 && dimension !== 1) {
+                // Example: <pid> (groupNameA+groupNameB+groupNameC+etc…)
+                const set = new Set();
+                dataPart.forEach(p => set.add(p.name.split(':')[1]));
+                const groupNames = Array.from(set.keys()).slice(0, 3).join('+') + (set.size > 3 ? '+etc…' : '');
+                groupedName += ` (${groupNames})`;
+            }
             const aggregate = dataPart.reduce((reduced, point) => reduced + point.after - point.before, 0);
             return {name: groupedName, aggregate};
         }).sort((a, b) => b.aggregate - a.aggregate);
+
         // Sum all time in this particular group for percentage
         const totalAggregateTime = points.reduce((reduced, {aggregate}) => reduced + aggregate, 0);
+
         // Textify
-        const tabledText = table(points.map(({name, aggregate}) => {
+        const tabledText = points.map(({name, aggregate}) => {
             const percent = aggregate / totalAggregateTime * 100;
             // 7 for the time string, 4 for percent string, 3 to compensate for column char of the table
             const maxBarSize = (process.stdout.columns || 80) - this.nameMaxLen - 7 - 4 - 6;
-
             return [
                 // maximum of 20
-                padRight(name.slice(0, this.nameMaxLen), this.nameMaxLen - indentation * 2),
+                padRight(new Array(indentation + 1).join('  ') + name.slice(0, this.nameMaxLen), this.nameMaxLen),
                 // max of 7 characters
                 padLeft(prettyMs(aggregate).slice(0, 7), 7),
                 getBarText(percent, maxBarSize),
                 // maximum of 4 character (number + '%')
                 padLeft(`${Math.round(percent)}%`, 4),
-            ];
-        }), {align: ['l', 'r', 'l', 'r']});
+            ].join('  ');
+        }).join('\n');
 
-        println(tabledText, indentation);
+        // Print the table!
+        console.log(tabledText);
     }
 
     print(data) {
-        console.log(chalk.bgWhite.black('Sorted by grouping (aggregate of all thread)'));
-        this._print(data, [1], 1);
+        console.log(chalk.bgWhite.black(padRight(' Sorted by grouping (aggregate of all thread)', process.stdout.columns || 80)));
+        this._print(data, [1]);
 
-        console.log(chalk.bgWhite.black('Sorted by subgroup'));
+        console.log(chalk.bgWhite.black(padRight(' Sorted by subgroup', process.stdout.columns || 80)));
         this._print(data, [1, 2]);
 
-        console.log(chalk.bgWhite.black('Sorted by pid'));
-        this._print(data, [1, 0]);
+        console.log(chalk.bgWhite.black(padRight(' Sorted by pid', process.stdout.columns || 80)));
+        this._print(data, [0]);
 
         console.log((new Array((process.stdout.columns || 80) + 1)).join(figure.line));
         console.log(chalk.white(`Process finished in ${chalk.bold(prettyMs(Date.now() - this.processStart))}.`));

--- a/packages/mendel-pipeline/src/registry/index.js
+++ b/packages/mendel-pipeline/src/registry/index.js
@@ -20,12 +20,18 @@ class MendelRegistry extends EventEmitter {
     }
 
     addToPipeline(dirPath) {
-        this.emit('directoryAdded', null, dirPath);
+        this.emit('entryRequested', null, dirPath);
     }
 
-    addEntry(filePath, rawSource) {
-        this._mendelCache.addEntry(filePath, rawSource);
-        this.emit('sourceAdded', this._mendelCache.getEntry(filePath));
+    addEntry(filePath) {
+        this._mendelCache.addEntry(filePath);
+        this.emit('entryAdded', this._mendelCache.getEntry(filePath));
+    }
+
+    addRawSource(filePath, source) {
+        const entry = this._mendelCache.getEntry(filePath);
+        entry.setSource(['raw'], source);
+        this.emit('sourceAdded', entry);
     }
 
     addTransformedSource({filePath, transformIds, effectiveExt, source}) {

--- a/packages/mendel-pipeline/src/step/deps/index.js
+++ b/packages/mendel-pipeline/src/step/deps/index.js
@@ -1,12 +1,9 @@
-/**
- * Independent/Isolated file transform
- */
 const analyticsCollector = require('../../helpers/analytics/analytics-collector');
+const analytics = require('../../helpers/analytics/analytics')('ipc');
 const debug = require('debug')('mendel:deps:master');
 const EventEmitter = require('events').EventEmitter;
 const {fork} = require('child_process');
 const numCPUs = require('os').cpus().length;
-const {extname} = require('path');
 
 /**
  * Knows how to do all kinds of trasnforms in parallel way
@@ -79,6 +76,8 @@ class DepsManager extends EventEmitter {
         const {filePath, source, variation} = this._queue.shift();
         const workerId = this._idleWorkerQueue.shift();
         const workerProcess = this._workerProcesses.find(({pid}) => workerId === pid);
+
+        analytics.tic('deps');
         workerProcess.send({
             type: 'start',
             filePath,
@@ -89,6 +88,7 @@ class DepsManager extends EventEmitter {
             baseName: this._baseConfig.id,
             varDirs: this._variationConfig.variationDirs,
         });
+        analytics.toc('deps');
         this.next();
     }
 }

--- a/packages/mendel-pipeline/src/step/deps/worker.js
+++ b/packages/mendel-pipeline/src/step/deps/worker.js
@@ -1,4 +1,5 @@
 const analytics = require('../../helpers/analytics/analytics-worker')('deps');
+const analyticsIpc = require('../../helpers/analytics/analytics-worker')('ipc');
 const debug = require('debug')('mendel:deps:slave-' + process.pid);
 const dep = require('mendel-deps');
 const path = require('path');
@@ -25,7 +26,9 @@ process.on('message', ({type, filePath, source, variation, cwd, baseDir, baseNam
         .then((deps) => {
             analytics.toc();
             debug(`Dependencies for ${filePath} found!`);
+            analyticsIpc.tic('deps');
             process.send({type: 'done', filePath, deps});
+            analyticsIpc.toc('deps');
         })
         .catch(error => {
             console.error(error.stack);

--- a/packages/mendel-pipeline/src/transformer/index.js
+++ b/packages/mendel-pipeline/src/transformer/index.js
@@ -1,7 +1,8 @@
 /**
  * Independent/Isolated file transform
  */
- const analyticsCollector = require('../helpers/analytics/analytics-collector');
+const analyticsCollector = require('../helpers/analytics/analytics-collector');
+const analytics = require('../helpers/analytics/analytics')('ipc');
 const debug = require('debug')('mendel:transformer:master');
 const {fork} = require('child_process');
 const {resolve: pathResolve} = require('path');
@@ -35,7 +36,9 @@ const parallelMode = (function() {
             workerProcess.removeListener('message', onMessage);
             next();
         });
+        analytics.tic('transform');
         workerProcess.send({type: 'start', transforms, filename, source});
+        analytics.toc('transform');
         next();
     }
 

--- a/packages/mendel-pipeline/src/transformer/worker.js
+++ b/packages/mendel-pipeline/src/transformer/worker.js
@@ -1,4 +1,5 @@
 const analytics = require('../helpers/analytics/analytics-worker')('transform');
+const analyticsIpc = require('../helpers/analytics/analytics-worker')('ipc');
 const debug = require('debug')('mendel:transformer:slave-' + process.pid);
 
 debug(`[Slave ${process.pid}] online`);
@@ -31,7 +32,9 @@ process.on('message', ({type, transforms, source, filename}) => {
 
         promise.then(({source, map}) => {
             debug(`[Slave ${process.pid}] Transform done.`);
+            analyticsIpc.tic('transform');
             process.send({type: 'done', filename, source, map});
+            analyticsIpc.toc('transform');
         })
         .catch(error => {
             console.log(error.stack);


### PR DESCRIPTION
1. Now tree=watch+fs is separated into separate steps.
2. The reason why pretty printer was broken is... text-table re-aligns based on max number of characters on each rows and it was counting bash coloring part of the string as length (something that goes like \[30;) and was aligning so badly. Took it out.

New screenshot looks like following:
<img width="939" alt="screen shot 2016-11-09 at 11 41 39 pm" src="https://cloud.githubusercontent.com/assets/2547313/20168290/1ea51ce2-a6d6-11e6-9a58-340d45471f70.png">


