### PR TITLE
More fully featured manifest-extract-bundles

### DIFF
--- a/examples/full-example/.mendelrc
+++ b/examples/full-example/.mendelrc
@@ -16,7 +16,6 @@ bundles:
     external:
       - react
       - react-dom
-      - ./isomorphic/base/components/lazy.js
     transform:
       - babelify
   lazy:

--- a/packages/mendel-manifest-extract-bundles/manifest-extract.js
+++ b/packages/mendel-manifest-extract-bundles/manifest-extract.js
@@ -10,57 +10,142 @@ function manifestExtractBundles(manifests, options, next) {
     var fromManifest = manifests[options.from];
     var externalManifest = manifests[options.external];
 
-    var fromFiles = Object.keys(fromManifest.indexes);
-    var externalFiles = Object.keys(externalManifest.indexes);
+    var fromFiles = function() {
+        return Object.keys(fromManifest.indexes);
+    };
+    var externalFiles = function() {
+        return Object.keys(externalManifest.indexes);
+    };
 
-    var intersection = externalFiles.filter(function(file) {
-        return fromFiles.indexOf(file) >= 0;
+    // Modules that are exposed on "external" should be removed from main
+    filterFilesFromManifest(fromManifest, function(file) {
+        var modIndex = externalFiles().indexOf(file);
+        var isExposedOnExternalBundle = false;
+        if (-1 !== modIndex) {
+            var externalMod = externalManifest.bundles[modIndex];
+            if (externalMod.expose) {
+                isExposedOnExternalBundle = true;
+            }
+        }
+        return !isExposedOnExternalBundle;
+    }, options.from);
+
+    // Cleanup potetial sub-dependencies of removed files
+    removeOrphans(fromManifest, options.from);
+
+    // Files that exist on main should be removed from external
+    var removedFromExternal = [];
+    filterFilesFromManifest(externalManifest, function(file) {
+        if (fromFiles().indexOf(file) >= 1) {
+            removedFromExternal.push(file);
+            return false;
+        }
+        return true;
+    }, options.external);
+
+    // Cleanup potetial sub-dependencies of removed files
+    removeOrphans(externalManifest, options.external);
+
+    // Files that exist on main and were removed from external bundle
+    // should be exposed on main
+    fromFiles().forEach(function(file) {
+        var moduleIndex = fromManifest.indexes[file];
+        var bundle = fromManifest.bundles[moduleIndex];
+        if (removedFromExternal.indexOf(file) > -1) {
+            bundle.expose = bundle.id;
+            bundle.variations.forEach(function(variation, index) {
+                bundle.data[index].expose = bundle.id;
+            });
+            debug(bundle.id + ' exposed on ' + options.from);
+        }
     });
 
     debug([
-        'found', intersection.length, 'files intersecting between',
-        options.from, 'and', options.external
+        fromFiles().length, 'files remaining in',
+        options.from, 'after extraction',
+    ].join(' '));
+    debug([
+        externalFiles().length, 'files remaining in',
+        options.external, 'after extraction',
     ].join(' '));
 
-    // Expose files on the source bundle
-    intersection.forEach(function(file) {
-        var moduleIndex = fromManifest.indexes[file];
-        var bundle = fromManifest.bundles[moduleIndex];
-        bundle.expose = bundle.id;
-        bundle.variations.forEach(function(variation, index) {
-            bundle.data[index].expose = bundle.id;
-        });
-    });
+    next(manifests);
+}
 
-    // Make modules external on the external bundle
+/*
+receives a manifest and a "selector" function
+modifies manifest indexes to include only files that selector returns truthy
+*/
+function filterFilesFromManifest(manifest, selector, logName) {
     // By removing files from the index, when the manifest is sorted and
     // validated, unreachable modules are removed.
-    externalManifest.indexes = externalFiles.reduce(function(indexes, file) {
-        if (-1 === intersection.indexOf(file)) {
-            indexes[file] = externalManifest.indexes[file];
+    var removedFiles = [];
+    manifest.indexes = Object.keys(manifest.indexes)
+    .reduce(function(indexes, file) {
+        if (selector(file)) {
+            indexes[file] = manifest.indexes[file];
+        } else {
+            removedFiles.push(file);
+            debug(file + ' removed from ' + logName);
         }
         return indexes;
     }, {});
 
     // Also, we need to make sure deps are updated to "false", which marks
     // the dep as external
-    Object.keys(externalManifest.indexes).forEach(function(file) {
-        var bundle = externalManifest.bundles[externalManifest.indexes[file]];
+    Object.keys(manifest.indexes).forEach(function(file) {
+        var bundle = manifest.bundles[manifest.indexes[file]];
         bundle.data.forEach(function(module) {
             Object.keys(module.deps).forEach(function(key) {
                 var value = module.deps[key];
-                if (intersection.indexOf(value) >=0) {
+                if (removedFiles.indexOf(value) >=0) {
                     module.deps[key] = false;
                 }
             });
         });
     });
-
-    var remaining = Object.keys(externalManifest.indexes).length;
-    debug([
-        remaining, 'files remaining in',
-        options.external, 'after extraction'
-    ].join(' '));
-
-    next(manifests);
 }
+
+/*
+walks the manifest dependencies and remove indexes that are unreachable
+*/
+function removeOrphans(manifest, logName) {
+    var originalIndexes = Object.keys(manifest.indexes);
+
+    // hashtable for number of time a bundle was visited
+    var visitedIndexes = originalIndexes.reduce(function(indexes, file) {
+        indexes[file] = false;
+        return indexes;
+    }, {});
+
+    // recursive function to visit bundle and it's deps
+    function visitBundle(file) {
+        if (visitedIndexes[file]) {
+            return;
+        }
+        visitedIndexes[file] = true;
+        // walk deps
+        var bundle = manifest.bundles[manifest.indexes[file]];
+        bundle.data.forEach(function(module) {
+            Object.keys(module.deps).forEach(function(key) {
+                var value = module.deps[key];
+                if (visitedIndexes.hasOwnProperty(value)) {
+                    visitBundle(value);
+                }
+            });
+        });
+    }
+
+    // start visiting from entries and exposed
+    originalIndexes.forEach(function(file) {
+        var bundle = manifest.bundles[manifest.indexes[file]];
+        if (bundle.expose || bundle.entry) {
+            visitBundle(file);
+        }
+    });
+
+    filterFilesFromManifest(manifest, function(file) {
+        return visitedIndexes.hasOwnProperty(file) && visitedIndexes[file];
+    }, logName);
+}
+

--- a/packages/mendel-manifest-extract-bundles/package.json
+++ b/packages/mendel-manifest-extract-bundles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-manifest-extract-bundles",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Parses a list of manifests, extract common dependencies and expose them from the parent bundle.",
   "main": "manifest-extract.js",
   "scripts": {

--- a/test/manifest-extract.js
+++ b/test/manifest-extract.js
@@ -11,7 +11,8 @@ var tmp = require('tmp');
 var realSamples = path.join(__dirname, './manifest-samples/');
 var copySamples = tmp.dirSync().name;
 
-var postProcessManifests = require('../packages/mendel-cli/post-process-manifest');
+var postProcessManifests = require(
+    '../packages/mendel-cli/post-process-manifest');
 var extract = require('../packages/mendel-manifest-extract-bundles');
 
 test('postProcessManifests applying post-processors', function (t) {
@@ -23,17 +24,17 @@ test('postProcessManifests applying post-processors', function (t) {
         manifestProcessors:[
             [extract, {
                 from: "bad-sort",
-                external: "foo-is-children"
+                external: "foo-is-children",
             }],
         ],
         outdir: copySamples,
         bundles: [{
             // just re-using, important part is that are some files there
             bundleName: 'bad-sort',
-            manifest: 'bad-sort.manifest.json'
+            manifest: 'bad-sort.manifest.json',
         }, {
             bundleName: 'foo-is-children',
-            manifest: 'foo-is-children.manifest.json'
+            manifest: 'foo-is-children.manifest.json',
         }],
     }, function(error) {
         t.error(error);

--- a/test/manifest-samples/bad-sort.manifest.json
+++ b/test/manifest-samples/bad-sort.manifest.json
@@ -2,7 +2,8 @@
   "indexes": {
     "zoo": 0,
     "foo": 1,
-    "bar": 2
+    "bar": 2,
+    "root": 3
   },
   "bundles": [
     {"variations": ["var"],
@@ -18,6 +19,15 @@
       "deps": {
         "zoo":"zoo",
         "bar":"bar"
+      }
+    }]},
+    {"variations": ["var"],
+    "id": "root",
+    "entry":true,
+    "data": [{
+      "source": "",
+      "deps": {
+        "foo": "foo"
       }
     }]},
     {"variations": ["var"],

--- a/test/manifest-samples/foo-is-children.manifest.json
+++ b/test/manifest-samples/foo-is-children.manifest.json
@@ -5,12 +5,15 @@
     "other": 2
   },
   "bundles": [{
+    "id":"foo",
     "variations": ["var"],
     "data": [{
       "source": "",
       "deps": {}
     }]
   },{
+    "id": "parent",
+    "entry": true,
     "variations": ["var"],
     "data": [{
       "source": "",
@@ -20,6 +23,7 @@
       }
     }]
   },{
+    "id": "other",
     "variations": ["var"],
     "data": [{
       "source": "",

--- a/test/post-process-manifest.js
+++ b/test/post-process-manifest.js
@@ -11,7 +11,8 @@ var tmp = require('tmp');
 var realSamples = path.join(__dirname, './manifest-samples/');
 var copySamples = tmp.dirSync().name;
 
-var postProcessManifests = require('../packages/mendel-cli/post-process-manifest');
+var postProcessManifests = require(
+    '../packages/mendel-cli/post-process-manifest');
 
 test('postProcessManifests loads manifests', function (t) {
     copyRecursiveSync(realSamples, copySamples);
@@ -21,7 +22,7 @@ test('postProcessManifests loads manifests', function (t) {
         outdir: copySamples,
         bundles: [{
             bundleName: 'minimal',
-            manifest: 'minimal.manifest.json'
+            manifest: 'minimal.manifest.json',
         }],
     }, t.error);
 });
@@ -34,15 +35,15 @@ test('postProcessManifests sorts and cleans manifests', function (t) {
         outdir: copySamples,
         bundles: [{
             bundleName: 'bad-sort',
-            manifest: 'bad-sort.manifest.json'
+            manifest: 'bad-sort.manifest.json',
         }],
     }, function(error) {
         t.error(error);
         var result = require(path.join(copySamples, 'bad-sort.manifest.json'));
 
-        t.equal(result.bundles.length, 3, 'removed one unused bundle');
+        t.equal(result.bundles.length, 4, 'removed one unused bundle');
         t.deepEqual(result.indexes,
-            { bar: 0, foo: 1, zoo: 2 }, 'reordered indexes');
+            { bar: 0, foo: 1, root:2, zoo: 3 }, 'reordered indexes');
         t.deepEqual(Object.keys(result.bundles[1].data[0].deps),
             ["bar", "zoo"], 'reordered deps');
     });
@@ -57,7 +58,7 @@ test('postProcessManifests validates manifests', function (t) {
         outdir: copySamples,
         bundles: [{
             bundleName: 'bad',
-            manifest: 'bad.manifest.json'
+            manifest: 'bad.manifest.json',
         }],
     }, function(err) {
         t.equal(err.code, "INVALID_MANIFEST", "should validate manifests");
@@ -82,12 +83,12 @@ test('postProcessManifests applying post-processors', function (t) {
     postProcessManifests({
         manifestProcessors:[
             [passThroughProcessor, {'LMAO':"the french smiley cat"}],
-            path.resolve(__filename)
+            path.resolve(__filename),
         ],
         outdir: copySamples,
         bundles: [{
             bundleName: 'minimal',
-            manifest: 'minimal.manifest.json'
+            manifest: 'minimal.manifest.json',
         }],
     }, function(error) {
         t.error(error);


### PR DESCRIPTION
This makes sure we remove files consistently regardless of variations, it cleans up orphans and prevent problems where some variations are lazy and some variations are not.