### PR TITLE
Implement simple case of `normalizedId`. Works with most reasonable projects

### DIFF
--- a/packages/mendel-config/src/base-config.js
+++ b/packages/mendel-config/src/base-config.js
@@ -1,17 +1,23 @@
-var path = require('path');
-var createValidator = require('./validator');
-
-function BaseConfig(config) {
-    var baseConfig = config['base-config'];
-    this.id = baseConfig.id;
-    this.dir = path.resolve(config.cwd, baseConfig.dir || '');
-
-    BaseConfig.validate(this);
-}
-
-BaseConfig.validate = createValidator({
+const path = require('path');
+const createValidator = require('./validator');
+const validate = createValidator({
     id: {required: true},
     dir: {required: true},
 });
+
+function BaseConfig(config) {
+    const input = config.baseConfig;
+
+    validate(input);
+
+    const baseConfig = {
+        id: input.id,
+        dir: path.relative(config.projectRoot, input.dir),
+    };
+    baseConfig.resolved = path.resolve(config.projectRoot, baseConfig.dir);
+
+    return baseConfig;
+}
+
 
 module.exports = BaseConfig;

--- a/packages/mendel-config/src/defaults.js
+++ b/packages/mendel-config/src/defaults.js
@@ -4,12 +4,12 @@
 
 module.exports = function() {
     return {
-        cwd: process.cwd(),
+        projectRoot: process.cwd(),
         'base-config': {
             id: 'base',
             dir: process.cwd(),
         },
-        'build-dir': 'mendel-build',
+        'build-dir': 'build',
         'variation-config': {
             'variation-dirs': [],
             variations: {},

--- a/packages/mendel-config/variations.js
+++ b/packages/mendel-config/variations.js
@@ -6,39 +6,55 @@ var fs = require('fs');
 var path = require('path');
 
 module.exports = function(config) {
-    var basedir = config.basedir || process.cwd();
-    var root = config.variationsdir || config.vasriations_root || "";
-    var vars = config.variations || {};
+    var projectRoot = config.projectRoot || config.basedir || process.cwd();
 
-    var variations = Object.keys(vars).map(function(dir) {
-        if(dir === '_') return;
-        if (Array.isArray(vars[dir] && vars[dir]._)) {
-            vars[dir] = vars[dir]._;
+    var variationConfig = config.variationConfig || {};
+    var variations = config.variations || variationConfig.variations || {};
+    var baseVariationDir = config.basetree || config.base;
+
+    if (config.variationConfig) {
+        var dirs = [].concat(variationConfig.variationDirs).filter(Boolean);
+        baseVariationDir = config.baseConfig.dir;
+        return dirs.reduce(function(allVariations, dir) {
+            return allVariations.concat(variationsForDir(variations, dir));
+        }, []);
+    } else {
+        // legacy
+        var dir = config.variationsdir || config.vasriations_root || "";
+        return variationsForDir(variations, dir);
+    }
+
+    function variationsForDir(vars, variationRoot) {
+        return Object.keys(vars).map(function(dir) {
+            if(dir === '_') return;
+            if (Array.isArray(vars[dir] && vars[dir]._)) {
+                vars[dir] = vars[dir]._;
+            }
+
+            var chain = [dir]
+                        .concat(Array.isArray(vars[dir]) ? vars[dir] : [])
+                        .map(relativeRoot)
+                        .filter(existsInProjectRoot);
+
+            return {
+                id: dir,
+                chain: chain.concat(baseVariationDir || projectRoot),
+            };
+        }).filter(function(variation) {
+            return variation
+                // we add base automatically, user can't add base on .mendelrc
+                && variation.id !== 'base'
+                && variation.chain.length > 1;
+        });
+
+        function relativeRoot(dir) {
+            return path.join(variationRoot, dir);
         }
 
-        var chain = [dir]
-                    .concat(Array.isArray(vars[dir]) ? vars[dir] : [])
-                    .map(relativeRoot)
-                    .filter(existsInBasedir);
-
-        return {
-            id: dir,
-            chain: chain.concat(config.basetree || config.base || basedir),
-        };
-    }).filter(function(variation) {
-        return variation
-            && variation.id !== 'base'
-            && variation.chain.length > 1;
-    });
-
-    function relativeRoot(dir) {
-        return path.join(root, dir);
     }
 
-    function existsInBasedir(dir) {
-        return fs.existsSync(path.join(basedir, dir));
+    function existsInProjectRoot(dir) {
+        return fs.existsSync(path.join(projectRoot, dir));
     }
-
-    return variations;
 };
 

--- a/packages/mendel-pipeline/package.json
+++ b/packages/mendel-pipeline/package.json
@@ -19,6 +19,7 @@
     "chokidar": "^1.6.0",
     "commander": "^2.9.0",
     "debug": "^2.2.0",
+    "mendel-development": "*",
     "mendel-deps": "*",
     "mendel-resolver": "^1.0.0",
     "pretty-ms": "^2.1.0",

--- a/packages/mendel-pipeline/src/cli.js
+++ b/packages/mendel-pipeline/src/cli.js
@@ -17,11 +17,12 @@ function parseIgnores(val='', previousIgnores) {
 program
     .version('0.1.0')
     .usage('[options] <dir path>')
-    .option('--ignore <patterns>', 'Comma separated ignore glob patterns', parseIgnores, ['**/_test_/**', '**/_browser_test_/**', '**/assets/**'])
+    .option('--ignore <patterns>', 'Comma separated ignore glob patterns',
+        parseIgnores, ['**/_test_/**', '**/_browser_test_/**', '**/assets/**'])
     // .option('-v, --verbose', 'Verbose mode')
     .option('-w, --watch', 'Watch mode', false)
     .parse(process.argv);
 
 // Example usage
-const mendelConfig = config(Object.assign(program, {cwd: path.resolve(process.cwd(), program.args[0])}));
+const mendelConfig = config(program);
 mendelPipeline(mendelConfig);

--- a/packages/mendel-pipeline/src/deps/index.js
+++ b/packages/mendel-pipeline/src/deps/index.js
@@ -43,6 +43,7 @@ class DepsManager {
                 resolve, reject,
                 filePath: entry.id,
                 source: entry.getSource(transformIds),
+                normalizedId: entry.normalizedId,
                 variation: entry.variation,
             });
         });
@@ -52,7 +53,7 @@ class DepsManager {
         if (!this._queue.length || !this._idleWorkerQueue.length) return;
 
         const self = this;
-        const {filePath, source, variation, resolve, reject} = this._queue.shift();
+        const {filePath, source, normalizedId, variation, resolve, reject} = this._queue.shift();
         const workerId = this._idleWorkerQueue.shift();
         const workerProcess = this._workerProcesses.find(({pid}) => workerId === pid);
 
@@ -78,13 +79,15 @@ class DepsManager {
         analytics.tic('deps');
         workerProcess.send({
             type: 'start',
+            // entry properties
             filePath,
+            normalizedId,
             variation,
             source,
+            // config properties
             projectRoot: this._projectRoot,
-            baseDir: this._baseConfig.dir,
-            baseName: this._baseConfig.id,
-            varDirs: this._variationConfig.variationDirs,
+            baseConfig: this._baseConfig,
+            variationConfig: this._variationConfig,
         });
         analytics.toc('deps');
         this.next();

--- a/packages/mendel-pipeline/src/deps/index.js
+++ b/packages/mendel-pipeline/src/deps/index.js
@@ -9,10 +9,10 @@ const numCPUs = require('os').cpus().length;
  */
 class DepsManager {
     /**
-     * @param {String} config.cwd
+     * @param {String} config.projectRoot
      */
-    constructor({cwd, baseConfig, variationConfig}) {
-        this._cwd = cwd;
+    constructor({projectRoot, baseConfig, variationConfig}) {
+        this._projectRoot = projectRoot;
         this._baseConfig = baseConfig;
         this._variationConfig = variationConfig;
         this._queue = [];
@@ -81,7 +81,7 @@ class DepsManager {
             filePath,
             variation,
             source,
-            cwd: this._cwd,
+            projectRoot: this._projectRoot,
             baseDir: this._baseConfig.dir,
             baseName: this._baseConfig.id,
             varDirs: this._variationConfig.variationDirs,

--- a/packages/mendel-pipeline/src/deps/worker.js
+++ b/packages/mendel-pipeline/src/deps/worker.js
@@ -7,15 +7,15 @@ const VariationalResolver = require('mendel-resolver/variational-resolver');
 
 debug(`[Slave ${process.pid}] online`);
 
-process.on('message', ({type, filePath, source, variation, cwd, baseDir, baseName, varDirs}) => {
+process.on('message', ({type, filePath, source, variation, projectRoot, baseDir, baseName, varDirs}) => {
     if (type === 'start') {
         debug(`Detecting dependencies for ${filePath}`);
 
         analytics.tic();
         const resolver = new VariationalResolver({
-            cwd,
+            projectRoot,
             envNames: ['main', 'browser'],
-            basedir: path.resolve(cwd, path.dirname(filePath)),
+            basedir: path.resolve(projectRoot, path.dirname(filePath)),
             baseVariationDir: baseDir,
             variationDirs: varDirs,
             variations: [variation, baseName],

--- a/packages/mendel-pipeline/src/step/fs-reader/index.js
+++ b/packages/mendel-pipeline/src/step/fs-reader/index.js
@@ -4,10 +4,10 @@ const fs = require('fs');
 const analytics = require('../../helpers/analytics/analytics')('fs');
 
 class FileReader extends BaseStep {
-    constructor({registry}, {types, cwd}) {
+    constructor({registry}, {types, projectRoot}) {
         super();
 
-        this.cwd = cwd;
+        this.projectRoot = projectRoot;
         this.registry = registry;
         this.sourceExt = new Set();
         Object.keys(types)
@@ -20,7 +20,7 @@ class FileReader extends BaseStep {
         const encoding = this.sourceExt.has(path.extname(filePath)) ? 'utf8' : 'binary';
 
         analytics.tic('read');
-        fs.readFile(path.resolve(this.cwd, filePath), encoding, (err, source) => {
+        fs.readFile(path.resolve(this.projectRoot, filePath), encoding, (err, source) => {
             if (err) {
                 // TODO handle the error
             }

--- a/packages/mendel-pipeline/src/step/fs-watcher/index.js
+++ b/packages/mendel-pipeline/src/step/fs-watcher/index.js
@@ -3,11 +3,11 @@ const chokidar = require('chokidar');
 const path = require('path');
 
 class FsWatcher extends BaseStep {
-    constructor({registry}, {cwd, ignore}) {
+    constructor({registry}, {projectRoot, ignore}) {
         super();
 
         this._registry = registry;
-        this.cwd = cwd;
+        this.projectRoot = projectRoot;
         // Default ignore .dot files.
         this.ignored = (ignore || []).concat([/[\/\\]\./]);
 
@@ -15,7 +15,11 @@ class FsWatcher extends BaseStep {
         this.isInitialized = false;
         this.initialProrityQueue = [];
 
-        this.watcher = new chokidar.FSWatcher({cwd: this.cwd, ignored: this.ignored});
+        this.watcher = new chokidar.FSWatcher({
+            cwd: this.projectRoot,
+            ignored: this.ignored,
+        });
+
         this.watcher
         .on('change', (path) => {
             this._registry.removeEntry(path);

--- a/packages/mendel-pipeline/src/step/fs-watcher/index.js
+++ b/packages/mendel-pipeline/src/step/fs-watcher/index.js
@@ -22,14 +22,16 @@ class FsWatcher extends BaseStep {
 
         this.watcher
         .on('change', (path) => {
+            path = withPrefix(path);
             this._registry.removeEntry(path);
             this._registry.addEntry(path);
             this.emit('done', {entryId: path});
         })
         .on('unlink', (path) => {
-            this._registry.removeEntry(path);
+            this._registry.removeEntry(withPrefix(path));
         })
         .on('add', (path, stats) => {
+            path = withPrefix(path);
             if (!this.isInitialized) return this.initialProrityQueue.push({path, size: stats.size});
 
             this._registry.addEntry(path);
@@ -61,6 +63,13 @@ class FsWatcher extends BaseStep {
     unsubscribe(path) {
         this.watcher.unwatch(path);
     }
+}
+
+function withPrefix(path) {
+    if (/^\w[^:]/.test(path)) {
+        path = './'+path;
+    }
+    return path;
 }
 
 function packageJsonSort(entry) {

--- a/packages/mendel-pipeline/src/step/initialize.js
+++ b/packages/mendel-pipeline/src/step/initialize.js
@@ -5,13 +5,13 @@ class Initialize {
      * @param {Array<String>} config.commonTransformIds
      * @param {Transformer} toolset.transformer
      */
-    constructor({registry}, {cwd}) {
-        this.cwd = cwd;
+    constructor({registry}, {projectRoot}) {
+        this.projectRoot = projectRoot;
         this.registry = registry;
     }
 
     start() {
-        // Listen to everything in cwd
+        // Listen to everything in projectRoot
         this.registry.addToPipeline('.');
     }
 }

--- a/packages/mendel-pipeline/src/step/initialize.js
+++ b/packages/mendel-pipeline/src/step/initialize.js
@@ -5,14 +5,15 @@ class Initialize {
      * @param {Array<String>} config.commonTransformIds
      * @param {Transformer} toolset.transformer
      */
-    constructor({registry}, {projectRoot}) {
+    constructor({registry}, {projectRoot, variationConfig}) {
         this.projectRoot = projectRoot;
         this.registry = registry;
+        this.allDirs = variationConfig.allDirs;
     }
 
     start() {
-        // Listen to everything in projectRoot
-        this.registry.addToPipeline('.');
+        // Add base and all variations to file watcher
+        this.registry.addToPipeline(this.allDirs);
     }
 }
 

--- a/packages/mendel-pipeline/src/transformer/index.js
+++ b/packages/mendel-pipeline/src/transformer/index.js
@@ -89,16 +89,19 @@ class TrasnformManager {
         this._transforms = new Map();
         transforms.forEach(transform => {
             this._transforms.set(transform.id, Object.assign(transform, {
-                plugin: this.resolvePlugin(config.cwd, transform.plugin),
+                plugin: this.resolvePlugin(
+                    config.projectRoot, transform.plugin),
             }));
         });
     }
 
-    resolvePlugin(cwd, plugin) {
-        if (existsSync(pathResolve(cwd, plugin))) return pathResolve(cwd, plugin);
+    resolvePlugin(projectRoot, plugin) {
+        if (existsSync(pathResolve(projectRoot, plugin))) {
+            return pathResolve(projectRoot, plugin);
+        }
 
-        // node_modules do not live in the cwd. We search where mendelrc is.
-        return moduleResolveSync(plugin, {basedir: process.cwd()});
+        // node_modules do not live in the source, use regular resolver
+        return moduleResolveSync(plugin, {basedir: projectRoot});
     }
 
     transform(filename, transformIds, source) {

--- a/packages/mendel-resolver/package.json
+++ b/packages/mendel-resolver/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/yahoo/mendel"
   },
   "dependencies": {
+    "mendel-development": "1.1.2"
   },
   "devDependencies": {
     "tap": "^7.1.2"

--- a/packages/mendel-resolver/test/index.js
+++ b/packages/mendel-resolver/test/index.js
@@ -1,6 +1,6 @@
 const test = require('tap').test;
 const Resolver = require('../');
-const VariationalResolver = require('../src/resolver/variational-resolver');
+const VariationalResolver = require('../variational-resolver');
 const fs = require('fs');
 const path = require('path');
 const basePath = path.resolve(__dirname, './fixtures');

--- a/packages/mendel-resolver/variational-resolver.js
+++ b/packages/mendel-resolver/variational-resolver.js
@@ -2,14 +2,14 @@ const ModuleResolver = require('./index');
 const path = require('path');
 
 class VariationalModuleResolver extends ModuleResolver {
-    constructor(config) {
-        super(config);
+    constructor({projectRoot, envNames, basedir, baseVariationDir, variationDirs, variations}) {
+        super({cwd: projectRoot, basedir, envNames});
 
         // Must be a path relative to the basedir
-        this.cwd = config.cwd;
-        this.baseVarDir = path.resolve(this.cwd, config.baseVariationDir);
-        this.varDirs = config.variationDirs.map(varDir => path.resolve(this.cwd, varDir));
-        this.variationChain = config.variations.reduce((reduced, variation) => {
+        this.projectRoot = projectRoot;
+        this.baseVarDir = path.resolve(projectRoot, baseVariationDir);
+        this.varDirs = variationDirs.map(varDir => path.resolve(projectRoot, varDir));
+        this.variationChain = variations.reduce((reduced, variation) => {
             return reduced.concat(this.varDirs.map(varDir => path.resolve(varDir, variation)));
         }, []).concat([this.baseVarDir]);
     }

--- a/test/config.js
+++ b/test/config.js
@@ -126,7 +126,7 @@ t.match(config(where), {
 where = './config-samples/4/';
 process.env.NODE_ENV = 'development';
 t.match(config(where), {
-    'base-config': {
+    baseConfig: {
         id: 'default',
         dir: /.*src\/default$/,
     },
@@ -145,7 +145,8 @@ t.match(config(where), {
             id: 'babelify-prod',
             plugin: 'mendel-babelify',
             options: {
-                plugins: ['react-intl-remove-description', 'transform-react-remove-prop-types'],
+                plugins: ['react-intl-remove-description',
+                'transform-react-remove-prop-types'],
             },
         },
         {
@@ -167,7 +168,7 @@ t.match(config(where), {
 
 process.env.NODE_ENV = 'production';
 t.match(config(where), {
-    'base-config': {
+    baseConfig: {
         id: 'default',
         dir: /.*src\/default$/,
     },


### PR DESCRIPTION
This PR is quite big and has a lot of chance for conflicts, so we should try to merge pretty fast.

@stephanwlee I suggest you read the commits in order, the last commit is already big in itself, but the first two are way simpler. Also, the 3 commits have large contextual commit messages.

Here is a summary of changes:

1. Make `projectRoot` consistent across all files and remove the option to pass in a folder to scrape. You can still pass in a directory, but we will look for mendelrc there, not source files directly.
2. Move all variation configuration logic and parsing to `mendel-config`. Also make most configs POJO so we don't have functions to serialize between processes as a nested object.
3. Implement `normalizedId` itself

Next step after this is merged is to code the colision detection when `package.json` is used inconsistently between variations.