### PR TITLE
additional tests info

### DIFF
--- a/docs/Tests.mdown
+++ b/docs/Tests.mdown
@@ -1,15 +1,15 @@
 ## Mendel Tests
 
-For the moment, Mendel relies on some private repository for integration tests. Make sure you have access to those in order to avoid integration breaking.
+For the moment, Mendel relies on some private repositories for integration tests. Make sure you have the appropriate access in order to run integration tests.
 
 ### Unit tests
 
 **File organization:**
 
-  * All tests are at the test directory
-  * All subdirectories are stubs and fixtures
+  * All tests are in the test/ directory
   * Each test files corresponds to exactly one source file
-  * All build/ directories are ignored, so if your tests generate something the output is not committed by accident.
+  * Only stubs and fixtures use subdirectories
+  * All build/ directories are ignored via the .gitignore to prevent generated output from being committed
 
 #### Running tests.
 
@@ -30,7 +30,7 @@ This will run coverage with command line output only and will only cover files t
 
     npm run coverage-html
 
-This will find all files in the application and report coverage on both command line and HTML output, as well as open your browser if possible.
+This will find all files in the application and report coverage in both the command line and HTML formats. If possible, it will as open your browser to view the report.
 
 To run tests against a single file you can:
 
@@ -42,7 +42,7 @@ We avoid mocking too much, so coverage might be biased when running the full sui
 
     npm run coverage-file test/testname.js
 
-Tests are written to target a single file, so when running the single test file, look for the corresponding source file, even though many files might show up in the result.
+Tests are written to target a single file, so when running the single test file, look for the corresponding source file, even though many files may show up in the result.
 
 Finally, if you want to find out if your changes are impacting those individual files coverage, there is a helper to loop through each test file running coverage and outputting summary to the terminal.
 

--- a/docs/Tests.mdown
+++ b/docs/Tests.mdown
@@ -7,17 +7,20 @@ For the moment, Mendel relies on some private repository for integration tests. 
 **File organization:**
 
   * All tests are at the test directory
-  * All subdirectories are stubs and fixtures\
-  * Every test files corresponds to exactly one source file
-  *  All build/ directories are ignored, so if your tests generate something the output is not committed by accident.
+  * All subdirectories are stubs and fixtures
+  * Each test files corresponds to exactly one source file
+  * All build/ directories are ignored, so if your tests generate something the output is not committed by accident.
 
 #### Running tests.
 
+If you have not already, please link all your local npm packages
+    npm run linkall
+
 To run tests quickly, please use:
 
-    npm test # all tests
-    npm runt unit # only unit tests
-    npm runt lint # only linter
+    npm test     # all tests
+    npm run unit # only unit tests
+    npm run lint # only linter
 
 If you want a quick coverage report of files and classes we already wrote tests, you can run:
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "async": "^2.1.2"
+    "async": "^2.1.2",
+    "tap": "^8.0.1"
   }
 }


### PR DESCRIPTION
I think it's helpful to add the `npm run linkall` step to the test page because I and many others start a new project by looking at the test coverage.

Changed some `npm runt` -> `npm run`

Added tap to the development dependencies because it appears to be needed to run the test suite.

Minor wording changes
