### PR TITLE
`normalizedId` now accounts for `package.json`

### DIFF
--- a/packages/mendel-pipeline/src/cache/entry.js
+++ b/packages/mendel-pipeline/src/cache/entry.js
@@ -5,6 +5,7 @@ class Entry {
         // property is filled by cache where they have more context
         this.normalizedId;
         this.variation;
+        this.runtime; // one of 'broser' or 'server'
 
         this.rawSource;
         this.source;

--- a/packages/mendel-pipeline/src/cache/entry.js
+++ b/packages/mendel-pipeline/src/cache/entry.js
@@ -5,7 +5,7 @@ class Entry {
         // property is filled by cache where they have more context
         this.normalizedId;
         this.variation;
-        this.runtime; // one of 'broser' or 'server'
+        this.runtime; // one of 'broser', 'server', 'package', 'isomorphic'
 
         this.rawSource;
         this.source;

--- a/packages/mendel-pipeline/src/cache/index.js
+++ b/packages/mendel-pipeline/src/cache/index.js
@@ -8,9 +8,12 @@ const variationMatches = require('mendel-development/variation-matches');
 class MendelCache extends EventEmitter {
     constructor(config) {
         super();
+        this.projectRoot = config.projectRoot;
         this.environment = config.environment;
         this._store = new Map();
         this._normalizedIdToEntryIds = new Map();
+        this._packageMap = new Map();
+        this._runtimeMap = new Map();
         this._baseConfig = config.baseConfig;
         this._variations = config.variationConfig.variations;
     }
@@ -29,6 +32,12 @@ class MendelCache extends EventEmitter {
             }
         }
 
+        if (this._packageMap.has(normalizedId)) {
+            const map = this._packageMap.get(normalizedId);
+            normalizedId = map.mapToId;
+            this._runtimeMap.set(id, map.runtime);
+        }
+
         return normalizedId;
     }
 
@@ -39,20 +48,85 @@ class MendelCache extends EventEmitter {
     }
 
     addEntry(id) {
-        if (!this._store.has(id)) {
-            const entry = new Entry(id);
-            entry.variation = this.getVariation(id);
-            entry.normalizedId = this.getNormalizedId(id);
+        if (this._store.has(id)) return;
 
-            if (!this._normalizedIdToEntryIds.has(entry.normalizedId)) {
-                this._normalizedIdToEntryIds.set(entry.normalizedId, []);
-            }
-            this._normalizedIdToEntryIds.get(entry.normalizedId).push(entry.id);
+        this.handleAsPackageJSON(id);
 
-            this._store.set(id, entry);
-            this.emit('entryAdded', id);
+        const entry = new Entry(id);
+
+        // normalize based on variation and environment
+        entry.variation = this.getVariation(id);
+        entry.normalizedId = this.getNormalizedId(id);
+        entry.runtime = this.getRuntime(id);
+
+        // fast lookup cache per normalized id
+        if (!this._normalizedIdToEntryIds.has(entry.normalizedId)) {
+            this._normalizedIdToEntryIds.set(entry.normalizedId, []);
         }
+        this._normalizedIdToEntryIds.get(entry.normalizedId).push(entry.id);
+
+        // finally
+        this._store.set(id, entry);
+        this.emit('entryAdded', id);
     }
+
+    handleAsPackageJSON(id) {
+        const parts = path.parse(id);
+        const packageNormId = this.getNormalizedId(id);
+        const pkgPath = path.join(this.projectRoot, id);
+
+        if (parts.base !== 'package.json') return;
+        if (this._normalizedIdToEntryIds.has(packageNormId)) {
+            /*
+              This should only happen in watch mode
+
+              TODO: It is possible to not throw here.
+
+              Mutating entries is not safe, since other async pieces of the
+              pipeline might be relying on this files already.
+
+              Here are some hypothesis on how to avoid throwing:
+              1. Restart the whole process automatically when this happens
+              2. Traverse all decendants from all variations and files from
+                 this normalizedId and remove them from the pipeline and
+                 traverse all the tree again with the new package.json
+            */
+            throw new Error([
+                `can't process ${id} after the`,
+                'following files are in the system:',
+                '\n',
+                this._normalizedIdToEntryIds.get(packageNormId).join('\n'),
+                '\n',
+            ].join(' '));
+        }
+
+        delete require.cache[require.resolve(pkgPath)];
+        const pkg = require(pkgPath);
+
+        ['browser', 'main'].forEach(runtime => {
+            if (!pkg[runtime]) return;
+            const targetNormId = this.getNormalizedId(
+                './' + path.join(parts.dir, pkg[runtime])
+            );
+            this._packageMap.set(targetNormId, {
+                mapToId: packageNormId,
+                runtime: runtime,
+            });
+        });
+    }
+
+    getRuntime(id) {
+        /about/.test(id) && console.log(id);
+        let runtime = 'isomorphic';
+        if (this._runtimeMap.has(id)) {
+            runtime = this._runtimeMap.get(id);
+        }
+        if (path.parse(id).base === 'package.json') runtime = 'package';
+        /about/.test(id) && console.log(runtime);
+        return runtime;
+    }
+
+
 
     doneEntry(id) {
         const entry = this.getEntry(id);


### PR DESCRIPTION
I feel like this is complete from the calculation side. I looked briefilly to the possibility of invalidating the files instead of throwing and added some inlide comments after I decided it is not time to do it.

There might be implications on what happens when we actually require `./components/about` on full example, as I didn't test this integration as of this commit. Once we do, there are implications for package.json, for instance, we have more than 1 `.components/about` for the `base` variation and we are not disambiguating.

Also, we can optimize the `deps` step to avoid filesystem sometimes. @stephanwlee did you notice how slow is deps in comparison to transforms now that GST is merged? It seems this optimization might be worthwhile after all.

Please, @stephanwlee please review carefully, I don't want to merge this yet without your feedback. Unless you think this is already good, in this case you can merge and work on top of it to avoid conflicts.