### PR TITLE
Show No.of entries collected per generator

### DIFF
--- a/packages/mendel-outlet-browser-pack/src/index.js
+++ b/packages/mendel-outlet-browser-pack/src/index.js
@@ -1,4 +1,4 @@
-const debug = require('debug')('mendel:outlet:manifest');
+const debug = require('debug')('mendel:outlet:browserpack');
 const fs = require('fs');
 const {Transform} = require('stream');
 const {Buffer} = require('buffer');

--- a/packages/mendel-pipeline/package.json
+++ b/packages/mendel-pipeline/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "chokidar": "^1.6.0",
+    "cli-table": "^0.3.1",
     "commander": "^2.9.0",
     "debug": "^2.2.0",
     "mendel-config": "^3.0.0-alpha.7",

--- a/packages/mendel-pipeline/src/cli.js
+++ b/packages/mendel-pipeline/src/cli.js
@@ -20,7 +20,6 @@ program
     .option('-o, --outlet', 'Write a mendel v1 compatible manifest', false)
     .parse(process.argv);
 
-
 if (program.watch) {
     const MendelPipelineDaemon = require('./daemon');
     const daemon = new MendelPipelineDaemon(program);

--- a/packages/mendel-pipeline/src/client/generators.js
+++ b/packages/mendel-pipeline/src/client/generators.js
@@ -1,11 +1,17 @@
 const DefaultGenerator = require('../bundles/default-generator');
 const debug = require('debug')('mendel:generators');
+const verbose = require('debug')('verbose:mendel:generators');
 const analyze = require('../helpers/analytics/analytics')('generator');
+const CliTable = require('cli-table');
 
 class MendelGenerators {
     constructor(options, registry) {
         this.registry = registry;
         this.options = options;
+        this.table = new CliTable({
+            head: ['Bundle', 'Generator ID', '# of Entries'],
+            colWidths: [15, 25, 15]
+        });
 
         this.generators = options.generators.map(generator => {
             return Object.assign({}, generator, {
@@ -43,6 +49,8 @@ class MendelGenerators {
                 `${resultBundle.entries.size} entries for`,
                 `bundle, "${bundle.options.id}"`,
             ].join(' '));
+
+            this.table.push([bundle.options.id, bundle.options.generator, resultBundle.entries.size]);
             doneBundles.push(resultBundle);
         }
 
@@ -59,6 +67,10 @@ class MendelGenerators {
         bundles.forEach(bundle => {
             this.perform(bundle, doneBundles);
         });
+
+        // Print number of entries collected by each generator.
+        verbose(this.table.toString());
+
         return doneBundles;
     }
 }

--- a/packages/mendel-pipeline/src/main.js
+++ b/packages/mendel-pipeline/src/main.js
@@ -12,7 +12,9 @@ class Mendel {
 
     constructor(config) {
         this.daemon = new Mendel.Daemon(config);
-        this.client = new Mendel.Client(Object.assign({verbose: false}, config));
+        this.client = new Mendel.Client(Object.assign({
+            verbose: false,
+        }, config));
     }
 
     run(callback) {


### PR DESCRIPTION
This data is displayed along with other analytics output of
mendel pipelien (when you run `mendel-pipeline` command with
no args).

```
[02:02:20 full-example] $ mendel-pipeline
┌────────────────────┬─────────────────────────┬──────────┐
│ Generator ID       │ Category                │ #Entries │
├────────────────────┼─────────────────────────┼──────────┤
│ main               │ default                 │ 198      │
├────────────────────┼─────────────────────────┼──────────┤
│ css                │ default                 │ 3        │
├────────────────────┼─────────────────────────┼──────────┤
│ lazy               │ extract-bundles         │ 3        │
├────────────────────┼─────────────────────────┼──────────┤
│ vendor             │ node-modules-generator  │ 177      │
└────────────────────┴─────────────────────────┴──────────┘
```

@stephanwlee Please review