### PR TITLE
Use sha-sum instead of integers in prune

### DIFF
--- a/packages/mendel-generator-prune/package.json
+++ b/packages/mendel-generator-prune/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/yahoo/mendel"
   },
   "dependencies": {
-    "debug": "^2.6.3"
+    "debug": "^2.6.3",
+    "shasum": "^1.0.2"
   }
 }


### PR DESCRIPTION
As of now, we are using incremented ids in prune post generator.
Order of files cannot be relied on and it causes unexpected
dependecy issues between multiple bundles. This is more vulnerable
when files are added or removed.

We should always create unique hash based on a file name. Irrespective of file order,
prune id should be unique.

@anuragdamle @irae @stephanwlee 