### PR TITLE
Return 500 and Log error when bundle is empty

### DIFF
--- a/packages/mendel-middleware/package.json
+++ b/packages/mendel-middleware/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "browser-pack": "^6.0.1",
+    "debug": "^2.6.3",
     "mendel-core": "^3.0.0",
     "mendel-loader": "^2.1.1",
     "path-to-regexp": "^1.2.1"


### PR DESCRIPTION
Sometimes, empty bundle is returned from mendel middleware. This gets cached in cdn or cache layers and served to more number of users.

We are still debugging the actual root cause of this issue, I have added logs to find no. of occurrences of this issue.

@anuragdamle @irae 