### PR TITLE
Add `falafel` as missing dependency of outlet server render

### DIFF
--- a/packages/mendel-outlet-server-side-render/package.json
+++ b/packages/mendel-outlet-server-side-render/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "debug": "^2.6.1",
+    "falafel": "^2.1.0",
     "mendel-development": "latest",
     "mendel-outlet-manifest": "^3.0.0"
   }


### PR DESCRIPTION
Here is how I found out this is needed:

  1. run `git clean -dfx`
  2. run `npm run linkall` from root
  3. run tests

A lot of things fail without falafel. I am pretty sure some people must have installed it by hand or even on their repo as dev-dependency because of this missing piece.

@anuragdamle @muralikr please take a look to review and merge as appropriate.