### PR TITLE
ensuring the default fallback is set for uglify

### DIFF
--- a/packages/mendel-manifest-uglify/manifest-uglify.js
+++ b/packages/mendel-manifest-uglify/manifest-uglify.js
@@ -9,14 +9,7 @@ module.exports = manifestUglify;
 
 function manifestUglify(manifests, options, next) {
     var optBundles = [].concat(options.bundles).filter(Boolean);
-    // `compress` and `mangle` are set to `true` on uglifyify
-    // just making sure we have the same defaults
-    var uglifyOptions = Object.assign({
-        compress: options.uglifyOptions.compress ? options.uglifyOptions.compress : true,
-        mangle: options.uglifyOptions.mangle ? options.uglifyOptions.mangle: true
-    }, options.uglifyOptions, {
-        fromString: true,
-    });
+    var uglifyOptions = Object.assign({}, options.uglifyOptions, {fromString: true});
 
     function whichManifests(manifest) {
         // default to all bundles

--- a/packages/mendel-manifest-uglify/package.json
+++ b/packages/mendel-manifest-uglify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-manifest-uglify",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Walks all manifest and apply UglifyJS to source",
   "main": "manifest-uglify.js",
   "scripts": {

--- a/packages/mendel-outlet-manifest/package.json
+++ b/packages/mendel-outlet-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-outlet-manifest",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mendel outlet for generating mendel-core (Mendel v1) compatible manifest. Manifest is a serialization of a Mendel cache.",
   "main": "src/index.js",
   "scripts": {

--- a/packages/mendel-outlet-manifest/src/index.js
+++ b/packages/mendel-outlet-manifest/src/index.js
@@ -85,10 +85,12 @@ module.exports = class ManifestOutlet {
 
     uglify(manifest) {
         manifestUglify([manifest], {
+            // `compress` and `mangle` are set to `true` on uglifyify
+            // just making sure we have the same defaults
             uglifyOptions: {
                 root: this.config.baseConfig.dir,
-                compress: this.options.compress,
-                mangle: this.options.mangle
+                compress: this.options.compress ? this.options.compress : true,
+                mangle: this.options.mangle ? this.options.mangle : true
             },
         }, ([uglifiedManifest]) => {
             // happens immediately


### PR DESCRIPTION
referencing this fix https://github.com/yahoo/mendel/pull/102 we observed that the default options for compress and uglify are not being set to `true`. This PR will rectify the fallback regression.

@irae @muralikr plz review.