### PR TITLE
Fix some `npm` warnings

### DIFF
--- a/examples/full-example/package.json
+++ b/examples/full-example/package.json
@@ -29,6 +29,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babelify": "^7.3.0",
+    "browserify": "^14.4.0",
     "chai": "^3.5.0",
     "envify": "^3.4.1",
     "eslint-plugin-react": "^5.2.2",
@@ -36,7 +37,7 @@
     "jsdom": "^9.9.1",
     "karma": "^1.3.0",
     "karma-babel-preprocessor": "^6.0.1",
-    "karma-browserify": "^5.1.0",
+    "karma-browserify": "^5.1.1",
     "karma-chrome-launcher": "^2.0.0",
     "karma-es6-shim": "^1.0.0",
     "karma-jasmine": "^1.0.2",
@@ -63,7 +64,8 @@
     "mocha-istanbul-reporter": "^0.1.0",
     "nodemon": "^1.9.2",
     "react-addons-test-utils": "^15.4.2",
-    "rtlcss": "^2.1.2"
+    "rtlcss": "^2.1.2",
+    "watchify": "^3.9.0"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -46,9 +46,7 @@
       "test/**"
     ]
   },
-  "dependencies": {
-    "mkdirp": "^0.5.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "async": "^2.1.2",
     "browserify": "^13.1.1",

--- a/packages/mendel-deps/package.json
+++ b/packages/mendel-deps/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "acorn": "^4.0.3",
     "acorn-jsx": "^3.0.1",
-    "ast-types": "^0.9.0"
+    "ast-types": "^0.9.11"
   },
   "devDependencies": {
     "glob": "^7.1.1",

--- a/packages/mendel-generator-extract/package.json
+++ b/packages/mendel-generator-extract/package.json
@@ -17,6 +17,5 @@
     "type": "git",
     "url": "https://github.com/yahoo/mendel"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/packages/mendel-generator-node-modules/package.json
+++ b/packages/mendel-generator-node-modules/package.json
@@ -17,6 +17,5 @@
     "type": "git",
     "url": "https://github.com/yahoo/mendel"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/packages/mendel-manifest-extract-bundles/package.json
+++ b/packages/mendel-manifest-extract-bundles/package.json
@@ -21,7 +21,5 @@
     "debug": "^2.3.3",
     "mendel-development": "^1.0.10"
   },
-  "devDependencies": {
-    "debug": "^2.3.3"
-  }
+  "devDependencies": {}
 }

--- a/packages/mendel-outlet-server-side-render/package.json
+++ b/packages/mendel-outlet-server-side-render/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mendel-outlet-server-side-render",
+  "description": "Writes out server-side compatible files for mendel-middleware in production mode",
   "version": "3.0.0",
-  "description": "",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/mendel-parser-json/package.json
+++ b/packages/mendel-parser-json/package.json
@@ -12,8 +12,7 @@
     "type": "git",
     "url": "https://github.com/yahoo/mendel"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "engines": {
     "node": ">=6.0"
   }


### PR DESCRIPTION
When running `npm run linkall` to install and cross-link for development, we get a log of warnings.

I solved all of them besides the ones in `full-example` that are related to sub-dependencies.

I tried to make this compatible with npm@5 but something is amiss, so I'll open a separate issue for that. Please test and try with npm@4.x.x for the time being.