### PR TITLE
Improved example of "support" field. 

### DIFF
--- a/examples/full-example/.mendelrc
+++ b/examples/full-example/.mendelrc
@@ -170,6 +170,9 @@ bundles: # Definition of a bundle
 
 env:
   test:
+    # test/setup/*.js are used only in test environment.
+    # Since they may pull in large test-related dependency in test environment,
+    # otherwise useless, Mendel supports "support" configuration.
     support: test/**/*.js
     types:
       js:

--- a/examples/full-example/isomorphic/base/components/_test_/button_test.js
+++ b/examples/full-example/isomorphic/base/components/_test_/button_test.js
@@ -12,8 +12,8 @@ import {expect} from 'chai';
 
 describe("Button", function() {
     it("renders with children", function() {
-        const button = renderIntoDocument(<Button>foo</Button>);
+        const button = renderIntoDocument(<Button>{this.sayMeow()}</Button>);
 
-        expect(findDOMNode(button).innerText).to.equal('foo');
+        expect(findDOMNode(button).innerText).to.equal('meow');
     });
 });

--- a/examples/full-example/package.json
+++ b/examples/full-example/package.json
@@ -4,9 +4,9 @@
   "description": "Example of app using mendel, es6, jsx, react, server-side-rendering, multivariant and multilayer support.",
   "main": "index.js",
   "scripts": {
-    "test": "mendel-mocha --prelude test/setup/jsdom.js **/_test_/*.js",
-    "test-dev": "mendel-mocha --prelude test/setup/jsdom.js **/_test_/*.js --watch",
-    "coverage": "mendel-mocha --prelude test/setup/jsdom.js **/_test_/*.js --reporter=mocha-istanbul-reporter --reporter-options=text,text-summary",
+    "test": "mendel-mocha --prelude 'test/setup.js' **/_test_/*.js",
+    "test-dev": "mendel-mocha --prelude 'test/setup/*.js' **/_test_/*.js --watch",
+    "coverage": "mendel-mocha --prelude 'test/setup/*.js' **/_test_/*.js --reporter=mocha-istanbul-reporter --reporter-options=text,text-summary",
     "build": "NODE_ENV=production mendel",
     "daemon": "mendel --watch",
     "development": "nodemon index.js",

--- a/examples/full-example/test/setup.js
+++ b/examples/full-example/test/setup.js
@@ -1,0 +1,2 @@
+require('./setup/jsdom');
+require('./setup/mocha-global');

--- a/examples/full-example/test/setup/mocha-global.js
+++ b/examples/full-example/test/setup/mocha-global.js
@@ -1,0 +1,15 @@
+/* eslint-env mocha */
+/**
+ * In a large project, one may want to inject utility functions in mocha
+ * context. This file shows an example of that.
+ */
+beforeEach(function() {
+    this.sayMeow = () => 'meow';
+    this.sayWoof = () => 'woof';
+});
+
+afterEach(function() {
+    if (this.sayMeow() !== 'meow') {
+        throw new Error('Not meow?!');
+    }
+});

--- a/packages/mendel-config/src/defaults.js
+++ b/packages/mendel-config/src/defaults.js
@@ -47,9 +47,11 @@ module.exports = function() {
         ignores: [],
         // This controls whether outlet outputs to a file or a stream
         noout: false, // TODO re-evaluate whether we need this guy
-        // In a large project, there are configuration/support related code
-        // that is not variatonal or should be bundled to browser.
-        // Takes glob as input
+        // In a large project, there are configuration/support/bootstrap code
+        // that is not variational or should be bundled to browser.
+        // Especially useful when the support code pulls in large dependency
+        // that you do not want to process/transpile in all environments.
+        // Takes (glob|path) as input.
         support: '',
     };
 };

--- a/packages/mendel-generator-extract/generator-extract.js
+++ b/packages/mendel-generator-extract/generator-extract.js
@@ -33,7 +33,6 @@ function generatorExtract(bundle, doneBundles, registry) {
     // Collect dependencies of main as if lazy was not there
     registry.getEntriesByGlob(fromBundle.options.entries)
     .forEach(({normalizedId, type}) => {
-        console.log(normalizedId, type)
         registry.walk(normalizedId, {types: [type]}, dep => {
             // Returning false stops from walking further
             // Since this code path is already visited; short circuit out of the

--- a/packages/mendel-mocha-runner/index.js
+++ b/packages/mendel-mocha-runner/index.js
@@ -38,6 +38,8 @@ function MendelRunner(filePaths, options={}) {
 
         const entries = client.registry.getEntriesByGlob(filePaths);
         entries.forEach(entry => {
+            // Pre-require populates mocha globals like before, beforeEach, and
+            // etc...
             mocha.suite.emit('pre-require', sandbox, entry.id, mocha);
 
             options.prelude.forEach(file => {

--- a/packages/mendel-pipeline/src/daemon.js
+++ b/packages/mendel-pipeline/src/daemon.js
@@ -163,6 +163,12 @@ module.exports = class MendelPipelineDaemon {
 
             this.cacheManager.sync(cache);
             this.pipelines[environment].watch();
+
+            // `config.support` is a special configuration
+            // that can dynamically add more entries to the pipeline.
+            if (envConf.support) {
+                this.watcher.subscribe([envConf.support]);
+            }
         }
         return this.pipelines[environment];
     }


### PR DESCRIPTION
full-example/package.json now includes different ways to
bootstrap test environment.

`npm run test` will bootstrap from "setup.js" whereas
`npm run test-dev` will bootstrap from glob
(all files - test/setup.js,test/setup/jsdom.js,test/setup/mocha-global.js)