### PR TITLE
Allow usage of `global` in isomorphic code

### DIFF
--- a/examples/full-example/isomorphic/base/components/footer.js
+++ b/examples/full-example/isomorphic/base/components/footer.js
@@ -4,9 +4,20 @@
 
 import React from 'react';
 
+global.foo = function() {
+    const env = process.env.NODE_ENV || 'development';
+    console.log(env);
+    return env;
+};
+
 class Footer extends React.Component {
     render() {
-        return <footer>--- footer stuff ---</footer>;
+        return (
+            <footer>
+                <div>--- footer stuff ---</div>
+                <div>Current NODE_ENV is {global.foo()}</div>
+            </footer>
+        );
     }
 }
 

--- a/packages/mendel-config/src/defaults.js
+++ b/packages/mendel-config/src/defaults.js
@@ -1,6 +1,7 @@
 /* Copyright 2015, Yahoo Inc.
    Copyrights licensed under the MIT License.
    See the accompanying LICENSE file for terms. */
+const path = require('path');
 
 module.exports = function() {
     const mendelEnv = process.env.MENDEL_ENV ||
@@ -42,8 +43,17 @@ module.exports = function() {
         env: {},
         bundles: {},
         config: true,
-        shim: {},
-        defaultShim: {},
+        shim: {
+            // Can pass any shim that would resolve modules differently.
+            // For instance, you can pass "fs" and name of the package
+            // to inject different implementation of "fs" instead of that of
+            // the browser.
+            // This would override "defaultShim" below.
+        },
+        defaultShim: {
+            // For Mendelv2, the default set of shim is listed in
+            // https://github.com/webpack/node-libs-browser.
+        },
         ignores: [],
         // This controls whether outlet outputs to a file or a stream
         noout: false, // TODO re-evaluate whether we need this guy

--- a/packages/mendel-deps/src/deps.js
+++ b/packages/mendel-deps/src/deps.js
@@ -1,6 +1,10 @@
 const acorn = require('acorn-jsx/inject')(require('acorn'));
 const {visit} = require('ast-types');
-const GLOBAL_WHITELIST = ['process'];
+// `console` is not included as it works flawlessly in Node and browser.
+const GLOBAL_WHITELIST = [
+    'global',
+    'process',
+];
 
 // {
 //     imports: ['./foo', '../bar', 'baz'],

--- a/packages/mendel-deps/test/fixtures/es5/index.js
+++ b/packages/mendel-deps/test/fixtures/es5/index.js
@@ -1,5 +1,7 @@
-const {hi} = require('./foo');
-console.log(process.env.NODE_ENV);
+const hi = require('./foo');
+function foo() {
+    global.console.log(process.env.NODE_ENV);
+}
 
 function bar() {}
 console.log(bar);

--- a/packages/mendel-deps/test/fixtures/es6/index.js
+++ b/packages/mendel-deps/test/fixtures/es6/index.js
@@ -1,2 +1,7 @@
 import {hi} from './foo';
-console.log(process.env.NODE_ENV);
+
+function foo() {
+    global.console.log(process.env.NODE_ENV);
+}
+
+console.log(hi);

--- a/packages/mendel-deps/test/index.js
+++ b/packages/mendel-deps/test/index.js
@@ -16,18 +16,14 @@ glob(__dirname + '/fixtures/**/*.js', null, function(err, files) {
     files
     .filter(file => file.endsWith('index.js'))
     .forEach(file => {
-        resolver.setBaseDir(path.dirname(file));
+        const dirname = path.dirname(file);
+        resolver.setBaseDir(dirname);
 
-        test(file, function(t) {
+        test(dirname, function(t) {
             return deps({source: readFileSync(file, 'utf8'), resolver})
             .then(deps => {
-                if (file.indexOf('no-global') >= 0) {
-                    // foo, Object
-                    t.equal(Object.keys(deps).length, 2);
-                } else {
-                    // foo, console, and process
-                    t.equal(Object.keys(deps).length, 3);
-                }
+                // foo, process, and global
+                t.equal(Object.keys(deps).length, 3);
 
                 const fooDep = deps['./foo'];
                 t.match(fooDep.browser, /foo\/browser.js$/);

--- a/packages/mendel-pipeline/src/daemon.js
+++ b/packages/mendel-pipeline/src/daemon.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('mendel:daemon');
+const path = require('path');
 const mendelConfig = require('mendel-config');
 
 const EventEmitter = require('events').EventEmitter;
@@ -72,7 +73,10 @@ class CacheManager extends EventEmitter {
 
 module.exports = class MendelPipelineDaemon {
     constructor(options) {
-        options = Object.assign({defaultShim: DefaultShims}, options);
+        const defaultShim = Object.assign({
+            global: path.join(__dirname, 'default-shims', 'global.js'),
+        }, DefaultShims);
+        options = Object.assign({defaultShim}, options);
         const config = mendelConfig(options);
         this.config = config;
 

--- a/packages/mendel-pipeline/src/default-shims/global.js
+++ b/packages/mendel-pipeline/src/default-shims/global.js
@@ -1,0 +1,1 @@
+global = window; // eslint-disable-line

--- a/packages/mendel-pipeline/src/registry/client.js
+++ b/packages/mendel-pipeline/src/registry/client.js
@@ -131,7 +131,7 @@ class MendelOutletRegistry {
             return;
         }
 
-        types = types.concat('node_modules');
+        types = types.concat('node_modules', '_others');
 
         Array.from(entryVariations.values())
         .filter(entry => {


### PR DESCRIPTION
@anuragdamle @irae 

By the way, the shims are not being used in any meaningful way as of right now.

Details:
If you see how we browser-pack, we did a quick hack to detect that a bundle requires a global like "process" (they are special in a sense that there won't be any "require" associated with it) and inject custom code. The custom code is the hacky part. Instead of requiring those shim like `(function(){process=require('process');...`, we effectively hand-written the same shims because method `require` is not defined yet and we need to have them before browser-pack's require function invokes the entries.

https://github.com/substack/browser-pack/blob/master/prelude.js#L40

We may be able to muck around with entry by prepending or passing custom prelude.js.
