### PR TITLE
Prevent requiring in transformer in Mendel-config

### DIFF
--- a/packages/mendel-config/src/transform-config.js
+++ b/packages/mendel-config/src/transform-config.js
@@ -1,18 +1,32 @@
 var createValidator = require('./validator');
 var nodeResolveSync = require('resolve').sync;
+var path = require('path');
+
+function _resolve(pluginPath, opt) {
+    try {
+        return nodeResolveSync(pluginPath, opt);
+    } catch (e) {
+        return false;
+    }
+}
+
 
 function TransformConfig(id, transform, {projectRoot}) {
     this.id = id;
+    const basedir = projectRoot;
+    const pluginPackagePath = _resolve(path.join(transform.plugin, 'package.json'), {basedir});
+    const pluginPath = _resolve(transform.plugin, {basedir});
 
-    try {
-        this.plugin = nodeResolveSync(transform.plugin, {basedir: projectRoot});
-        this.mode = require(this.plugin).mode || 'ist';
-    } catch (e) {
-        if (e.code !== 'MODULE_NOT_FOUND') throw e;
-        this.plugin = false;
+    if (pluginPath) {
+        this.mode = [pluginPackagePath, pluginPath]
+            .filter(Boolean)
+            .map(plugin => require(plugin).mode)
+            .filter(Boolean)[0] || 'ist';
+    } else {
         this.mode = 'unknown';
     }
 
+    this.plugin = pluginPath;
     this.options = transform.options;
 
     TransformConfig.validate(this);

--- a/packages/mendel-parser-json/package.json
+++ b/packages/mendel-parser-json/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Wraps JSON file in a JavaScript module for bundling with assets in Mendel",
   "main": "index.js",
+  "mode": "ist",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/mendel-transform-babel/package.json
+++ b/packages/mendel-transform-babel/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Mendel transforms that uses babel-core",
   "main": "index.js",
+  "mode": "ist",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/mendel-transform-less/package.json
+++ b/packages/mendel-transform-less/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Mendel transformer for LESS",
   "main": "index.js",
+  "mode": "ist",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Because of "require" (another option is to use AST parser),
for instance of transform-babel, we required all of babel which
contributed to large bootstrap time on low-powered computer.