### PR TITLE
Small fix to accept applications without ssr too

### DIFF
--- a/packages/mendel-core/trees.js
+++ b/packages/mendel-core/trees.js
@@ -24,9 +24,11 @@ function MendelTrees(opts) {
     this.ssrOutlet = this.config.outlets.find(outletConfig => {
         return outletConfig._plugin === 'mendel-outlet-server-side-render';
     });
-    this.ssrBundle = this.config.bundles.find(bundleConfig => {
-        return bundleConfig.outlet === this.ssrOutlet.id;
-    });
+    if (this.ssrOutlet) {
+        this.ssrBundle = this.config.bundles.find(bundleConfig => {
+            return bundleConfig.outlet === this.ssrOutlet.id;
+        });
+    }
 }
 
 MendelTrees.prototype.findTreeForVariations = function(bundle, lookupChains) {


### PR DESCRIPTION
I was testing mendel with a project without SSR and it throws when trying to create `ssrBundle` without any config bundles.

The rest of the code seems to have some checks without SSR, so this is the only small fix we need to support client-side only repos.