### PR TITLE
Bump versions semantically; 3.1.0 most packages

### DIFF
--- a/packages/mendel-config/package.json
+++ b/packages/mendel-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-config",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Mendel configuration parser",
   "main": "index.js",
   "scripts": {

--- a/packages/mendel-core/package.json
+++ b/packages/mendel-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-core",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Mendel shared dependencies production use",
   "main": "trees.js",
   "scripts": {

--- a/packages/mendel-deps/package.json
+++ b/packages/mendel-deps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-deps",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Depedency detector based on AST. Supports custom cache and custom resolver.",
   "main": "src/deps.js",
   "scripts": {

--- a/packages/mendel-development-middleware/package.json
+++ b/packages/mendel-development-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development-middleware",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Mendel middleware that executes and builds based on a Mendel client appropriate for during development.",
   "main": "index.js",
   "scripts": {
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "path-to-regexp": "^1.7.0",
-    "mendel-config": "^3.0.0",
+    "mendel-config": "^3.1.0",
     "mendel-development": "^1.1.0",
-    "mendel-exec": "^3.0.0",
-    "mendel-pipeline": "^3.0.0"
+    "mendel-exec": "^3.0.1",
+    "mendel-pipeline": "^3.1.0"
   }
 }

--- a/packages/mendel-exec/package.json
+++ b/packages/mendel-exec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-exec",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "JavaScript executor using VM and Mendelv2 for custom variational resolving.",
   "main": "index.js",
   "scripts": {

--- a/packages/mendel-middleware/package.json
+++ b/packages/mendel-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-middleware",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Mendel middleware that uses manifests to output multilayer resolution of isomorphic applications.",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
   "dependencies": {
     "browser-pack": "^6.0.1",
     "debug": "^2.6.3",
-    "mendel-core": "^3.0.0",
+    "mendel-core": "^3.0.1",
     "mendel-loader": "^2.1.1",
     "path-to-regexp": "^1.2.1"
   }

--- a/packages/mendel-mocha-runner/package.json
+++ b/packages/mendel-mocha-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-mocha-runner",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Mocha for Mendel. Mendel gains control of how sources are transformed and when and how to execute test",
   "main": "index.js",
   "scripts": {
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
-    "mendel-exec": "^3.0.0",
-    "mendel-pipeline": "^3.0.0",
+    "mendel-exec": "^3.0.1",
+    "mendel-pipeline": "^3.1.0",
     "mocha": "^3.2.0",
     "resolve": "^1.2.0"
   },

--- a/packages/mendel-outlet-browser-pack/package.json
+++ b/packages/mendel-outlet-browser-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-outlet-browser-pack",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Mendel outlet for JavaScript bundles using browser-pack.",
   "main": "src/index.js",
   "scripts": {

--- a/packages/mendel-outlet-server-side-render/package.json
+++ b/packages/mendel-outlet-server-side-render/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mendel-outlet-server-side-render",
   "description": "Writes out server-side compatible files for mendel-middleware in production mode",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/packages/mendel-pipeline/package.json
+++ b/packages/mendel-pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-pipeline",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "The mendel package",
   "main": "src/main.js",
   "bin": {
@@ -22,8 +22,8 @@
     "cli-table": "^0.3.1",
     "commander": "^2.9.0",
     "debug": "^2.2.0",
-    "mendel-config": "^3.0.0",
-    "mendel-deps": "^3.0.0",
+    "mendel-config": "^3.1.0",
+    "mendel-deps": "^3.1.0",
     "mendel-development": "^1.1.0",
     "mendel-resolver": "^3.0.0",
     "mkdirp": "^0.5.1",

--- a/packages/mendel-resolver/package.json
+++ b/packages/mendel-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-resolver",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "node-resolve + browser-resolve that is promise based in an OOP fashion",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
At this point, if I link all the packages I ran a lot of tests with a project recently migrated to mendel 3.x and everything seems to work fine.

I went through all the packages changes by git log and found all places that need bump. Most packages will go to 3.1 because we now support global shim and this is a new feature. Some packages tho I only bumped the patch version because we only include bug fixes.

I believe we have a solid release in hands for production. I'll push "beta" versions of those packages and mention in the comments in the next half-hour or so. I'll also try this version in production.

@muralikr @anuragdamle can you please make sure this version works for your application? Also, would you be so kind to pin to the exact version all packages in your application? This way the open source version can move faster, as discussed. Thanks!
