### PR TITLE
Avoid config requires

### DIFF
--- a/packages/mendel-config/src/outlet-config.js
+++ b/packages/mendel-config/src/outlet-config.js
@@ -1,20 +1,12 @@
 var createValidator = require('./validator');
-var nodeResolve = require('resolve').sync;
-
-function resolve(plugin, root) {
-    try {
-        return nodeResolve(plugin, {basedir: root});
-    } catch (e) {
-        if (e.code === 'MODULE_NOT_FOUND') return false;
-        throw e;
-    }
-}
+var resolvePlugin = require('./resolve-plugin');
 
 function OutletConfig({id, plugin, options={}}, {projectRoot}) {
     this.id = id;
     this._plugin = plugin;
-    this.plugin = resolve(plugin, projectRoot);
     this.options = options;
+
+    this.plugin = resolvePlugin(plugin, projectRoot).plugin;
 
     if (this.options.plugin) {
         if (!Array.isArray(this.options.plugin)) {
@@ -26,9 +18,9 @@ function OutletConfig({id, plugin, options={}}, {projectRoot}) {
             }
 
             if (typeof plugin === 'string')
-                return resolve(plugin, projectRoot);
+                return resolvePlugin(plugin, projectRoot).plugin;
 
-            plugin[0] = resolve(plugin[0], projectRoot);
+            plugin[0] = resolvePlugin(plugin[0], projectRoot).plugin;
             return plugin;
         });
     }

--- a/packages/mendel-config/src/resolve-plugin.js
+++ b/packages/mendel-config/src/resolve-plugin.js
@@ -1,0 +1,47 @@
+var nodeResolveSync = require('resolve').sync;
+var path = require('path');
+
+function resolvePlugin(pluginName, basedir) {
+    const pluginPackagePath = _resolve(path.join(pluginName, 'package.json'), {
+        basedir,
+    });
+    const pluginPath = _resolve(pluginName, {basedir});
+
+    const resolved = {
+        plugin: pluginPath,
+    };
+
+    resolved.mode = [pluginPackagePath, pluginPath].reduce((mode, path) => {
+        if (!mode) {
+            try {
+                const packageOrModule = require(path);
+                mode = packageOrModule.mode || 'ist';
+            } catch (e) {
+                // Nice try, but we don't need to do anything yet
+                // ¯\_(ツ)_/¯
+            }
+        }
+        return mode;
+    }, false);
+
+    resolved.mode = resolved.mode || 'unknown';
+
+    if (resolved.mode === 'unknown' && process.env.NODE_ENV !== 'production') {
+        console.error(
+            'WARN: ' + pluginName + ' was not found. Check your configuration '+
+            'or your "npm install --save-dev" your plugin'
+        );
+    }
+
+    return resolved;
+}
+
+function _resolve(pluginPath, opt) {
+    try {
+        return nodeResolveSync(pluginPath, opt);
+    } catch (e) {
+        return false;
+    }
+}
+
+module.exports = resolvePlugin;

--- a/packages/mendel-config/src/transform-config.js
+++ b/packages/mendel-config/src/transform-config.js
@@ -1,18 +1,32 @@
 var createValidator = require('./validator');
 var nodeResolveSync = require('resolve').sync;
+var path = require('path');
+
+function _resolve(pluginPath, opt) {
+    try {
+        return nodeResolveSync(pluginPath, opt);
+    } catch (e) {
+        return false;
+    }
+}
+
 
 function TransformConfig(id, transform, {projectRoot}) {
     this.id = id;
+    const basedir = projectRoot;
+    const pluginPackagePath = _resolve(path.join(transform.plugin, 'package.json'), {basedir});
+    const pluginPath = _resolve(transform.plugin, {basedir});
 
-    try {
-        this.plugin = nodeResolveSync(transform.plugin, {basedir: projectRoot});
-        this.mode = require(this.plugin).mode || 'ist';
-    } catch (e) {
-        if (e.code !== 'MODULE_NOT_FOUND') throw e;
-        this.plugin = false;
+    if (pluginPath) {
+        this.mode = [pluginPackagePath, pluginPath]
+            .filter(Boolean)
+            .map(plugin => require(plugin).mode)
+            .filter(Boolean)[0] || 'ist';
+    } else {
         this.mode = 'unknown';
     }
 
+    this.plugin = pluginPath;
     this.options = transform.options;
 
     TransformConfig.validate(this);

--- a/packages/mendel-config/src/transform-config.js
+++ b/packages/mendel-config/src/transform-config.js
@@ -1,33 +1,13 @@
 var createValidator = require('./validator');
-var nodeResolveSync = require('resolve').sync;
-var path = require('path');
-
-function _resolve(pluginPath, opt) {
-    try {
-        return nodeResolveSync(pluginPath, opt);
-    } catch (e) {
-        return false;
-    }
-}
-
+var resolvePlugin = require('./resolve-plugin');
 
 function TransformConfig(id, transform, {projectRoot}) {
     this.id = id;
-    const basedir = projectRoot;
-    const pluginPackagePath = _resolve(path.join(transform.plugin, 'package.json'), {basedir});
-    const pluginPath = _resolve(transform.plugin, {basedir});
-
-    if (pluginPath) {
-        this.mode = [pluginPackagePath, pluginPath]
-            .filter(Boolean)
-            .map(plugin => require(plugin).mode)
-            .filter(Boolean)[0] || 'ist';
-    } else {
-        this.mode = 'unknown';
-    }
-
-    this.plugin = pluginPath;
     this.options = transform.options;
+
+    var resolved = resolvePlugin(transform.plugin, projectRoot);
+    this.plugin = resolved.plugin;
+    this.mode = resolved.mode;
 
     TransformConfig.validate(this);
 }

--- a/packages/mendel-parser-json/package.json
+++ b/packages/mendel-parser-json/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Wraps JSON file in a JavaScript module for bundling with assets in Mendel",
   "main": "index.js",
+  "mode": "ist",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/mendel-transform-babel/package.json
+++ b/packages/mendel-transform-babel/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Mendel transforms that uses babel-core",
   "main": "index.js",
+  "mode": "ist",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/mendel-transform-less/package.json
+++ b/packages/mendel-transform-less/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Mendel transformer for LESS",
   "main": "index.js",
+  "mode": "ist",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This PR fixes two issues:

1. Config itself never uses the transforms, so `require`ing it is expensive and memory consuming for no reason. Without this we have faster startup for daemon in development mode
2. In production, if you `npm prune --production` you can't require the transforms since they are dev dependencies
3. When you first install mendel, it is tedious to fix one by one of the packages you might have forgotten, so this will also log to stdrr instead of throwing on the first not found package.