### PR TITLE
Add sorting and validation to all manifests in mendel-outlet-manifest

### DIFF
--- a/packages/mendel-development/package.json
+++ b/packages/mendel-development/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-development",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Mendel shared dependencies for build and development",
   "main": "index.js",
   "scripts": {

--- a/packages/mendel-development/post-process-manifest.js
+++ b/packages/mendel-development/post-process-manifest.js
@@ -83,10 +83,7 @@ function loadManifests(bundles, config, next) {
 
 function sortManifestProcessor(manifests, config, next) {
     Object.keys(manifests).forEach(function(bundleName) {
-        manifests[bundleName] = (sortManifest(
-            manifests[bundleName].indexes,
-            manifests[bundleName].bundles
-        ));
+        manifests[bundleName] = sortManifest(manifests[bundleName]);
     });
     next(manifests);
 }

--- a/packages/mendel-development/sort-manifest.js
+++ b/packages/mendel-development/sort-manifest.js
@@ -4,7 +4,9 @@
 
 module.exports = sortManifest;
 
-function sortManifest(inputIndexes, inputBundles) {
+function sortManifest(manifest) {
+    var inputIndexes = manifest.indexes;
+    var inputBundles = manifest.bundles;
     var sortedManifest = {
         indexes: {},
         bundles: [],

--- a/packages/mendel-outlet-manifest/package.json
+++ b/packages/mendel-outlet-manifest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-outlet-manifest",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Mendel outlet for generating mendel-core (Mendel v1) compatible manifest. Manifest is a serialization of a Mendel cache.",
   "main": "src/index.js",
   "scripts": {
@@ -17,6 +17,7 @@
     "babel-plugin-transform-inline-environment-variables": "0.0.2",
     "debug": "^2.6.0",
     "mendel-manifest-uglify": "^3.0.2",
+    "mendel-development": "^3.0.1",
     "shasum": "^1.0.2"
   }
 }

--- a/packages/mendel-outlet-manifest/src/index.js
+++ b/packages/mendel-outlet-manifest/src/index.js
@@ -3,6 +3,8 @@ const babelCore = require('babel-core');
 const manifestUglify = require('mendel-manifest-uglify');
 const fs = require('fs');
 const shasum = require('shasum');
+const sortManifest = require('mendel-development/sort-manifest');
+const validateManifest = require('mendel-development/validate-manifest');
 
 // Manifest
 module.exports = class ManifestOutlet {
@@ -16,6 +18,7 @@ module.exports = class ManifestOutlet {
             runtime: 'browser',
         }, options);
         this.runtime = this.options.runtime;
+        this.name = 'mendel-outlet-manifest';
     }
 
     perform({entries, options}) {
@@ -28,6 +31,9 @@ module.exports = class ManifestOutlet {
 
         if (this.options.envify) manifest = this.envify(manifest);
         if (this.options.uglify) manifest = this.uglify(manifest);
+        manifest = sortManifest(manifest);
+
+        validateManifest(manifest, manifestFileName, this.name);
 
         fs.writeFileSync(
             manifestFileName,


### PR DESCRIPTION
Mendel 2 is way better in terms of consistency. Simulating the validation errors is quite hard, but might happen in case of scenarios like missing files and deps. Validation is still useful in this scenarios since it forces production build to break when generating bundle manifests.

Sorting comes handy in the long term. Different teams might have different workflows. Some can build and commit manifest to git, others can package production builds with private instance of npm and others might have docker containers. What does not change is the ability to compare manifests between different production builds. Sorting becomes very valuable in this case, since generating a diff of changes is quite useful for debugging reasons, for bundle analysis and for debugging issues across mendel versions (although Mendel is quite stable now, it might happen in the future to beta users of next major versions).

This PR helps in both fronts by bringing back sort and validation functions that are quite stable and proven to be useful since Mendel v1.
