### PR TITLE
Support for node globals in production by using mendel-browser-pack

### DIFF
--- a/examples/full-example/package.json
+++ b/examples/full-example/package.json
@@ -8,6 +8,7 @@
     "test-dev": "mendel-mocha --prelude 'test/setup/*.js' **/_test_/*.js --watch",
     "coverage": "mendel-mocha --prelude 'test/setup/*.js' **/_test_/*.js --reporter=mocha-istanbul-reporter --reporter-options=text,text-summary",
     "build": "NODE_ENV=production mendel",
+    "build-files": "mendel",
     "daemon": "mendel --watch",
     "development": "nodemon index.js",
     "production": "NODE_ENV=production node index.js"

--- a/packages/mendel-browser-pack/index-deps.js
+++ b/packages/mendel-browser-pack/index-deps.js
@@ -1,0 +1,106 @@
+/**
+ * Modules internal to a bundle can be referenced by index instead of id.
+ * Remap ids and deps in such case.
+ * @example
+ * This compresses the bundle by renaming all dependency indexes from file paths
+ * to a numbered index.
+ *
+ * Here is a sample transformation:
+ * ```js
+ * [
+ *   {
+ *     "entry": true,
+ *     "id": "/User/me/projects/site/src/main.js",
+ *     "deps": {
+ *       "./colors.js": "/User/me/projects/site/src/colors.js",
+ *       "./shared.js": "/User/me/projects/site/src/shared.js"
+ *     }
+ *   },
+ *   {
+ *     "id": "/User/me/projects/site/src/colors.js",
+ *     "deps": {
+ *       "external-lib": false
+ *     }
+ *   },
+ *   {
+ *     "expose": "shared",
+ *     "id": "/User/me/projects/site/src/shared.js",
+ *     "deps": {}
+ *   }
+ * ]
+ * ```
+ *
+ * Should become:
+ * ```js
+ * [
+ *   {
+ *     "entry": true,
+ *     "id": 1,
+ *     "deps": {
+ *       "./colors.js": 2,
+ *       "./shared.js": "shared"
+ *     }
+ *   },
+ *   {
+ *     "id": 2,
+ *     "deps": {
+ *       "external-lib": false
+ *     }
+ *   },
+ *   {
+ *     "expose": "shared",
+ *     "id": "shared",
+ *     "deps": {}
+ *   }
+ * ]
+ * ```
+ */
+module.exports = function indexedDeps(mods) {
+    // the index can't be ever 0 because 0 is false for browserify
+    var newModIndex = [0];
+
+    // indexes are created first, because deps can come unordered
+    mods.forEach(function(mod){
+        if (!mod.expose) newModIndex.push(mod.id);
+    });
+
+    // create a new array of modified modules
+    return mods.map(function(oldMod) {
+        return Object.keys(oldMod).reduce(function(newMod, prop) {
+
+            if (prop === 'deps') { // deps needs to be reindexed
+                newMod.deps = Object.keys(oldMod.deps).reduce(
+                    function(newDeps, name) {
+                        var id = oldMod.deps[name];
+                        var index = newModIndex.indexOf(id);
+                        if (index > -1) {
+                            newDeps[name] = index;
+                        } else {
+                            // deps not indexed are exposed or external
+                            newDeps[name] = id;
+                        }
+                        return newDeps;
+                    },
+                {});
+            }
+
+
+            else if(prop === 'id') { // id needs to be reindexed
+                var index = newModIndex.indexOf(oldMod.id);
+                if (index > -1) {
+                    newMod.id = index;
+                } else {
+                    // unless it is entry or exposed
+                    newMod.id = oldMod.expose || oldMod.id;
+                }
+            }
+
+            else {
+                // for all other props we just copy over
+                newMod[prop] = oldMod[prop];
+            }
+
+            return newMod;
+        }, {});
+    });
+}

--- a/packages/mendel-browser-pack/index.js
+++ b/packages/mendel-browser-pack/index.js
@@ -87,6 +87,7 @@ module.exports = function mendelBrowserPack(bundleEntries, browserPackOptions) {
     });
     const hasGlobalDep = globalDepKeys.some(h => h);
     if (hasGlobalDep) bundleEntries = removeGlobalDep(bundleEntries);
+
     bundleEntries = indexedDeps(bundleEntries);
 
     let prelude = '';

--- a/packages/mendel-browser-pack/index.js
+++ b/packages/mendel-browser-pack/index.js
@@ -1,0 +1,110 @@
+const EXPOSE_GLOBAL = new Map([
+    ['global', 'var global=window;'],
+    ['process', 'var process=window.process||{env: {}};'],
+]);
+
+const {Transform} = require('stream');
+const {Buffer} = require('buffer');
+const browserpack = require('browser-pack');
+const indexedDeps = require('./index-deps');
+
+class PaddedStream extends Transform {
+    constructor({prelude='', appendix=''}, options) {
+        super(options);
+        this.prelude = prelude;
+        this.appendix = appendix;
+        this.started = false;
+    }
+    // Called on every chunk
+    _transform(chunk, encoding, cb) {
+        if (!this.started) {
+            this.started = true;
+            chunk = Buffer.concat([Buffer.from(this.prelude), chunk]);
+        }
+        cb(null, chunk);
+    }
+    // Called right before it wants to end
+    _flush(cb) {
+        this.push(Buffer.from(this.appendix));
+        cb();
+    }
+}
+
+function writeToStream(stream, arrData) {
+    if (!arrData.length) {
+        stream.end();
+        return;
+    }
+
+    // Writing null terminates the stream. It is equal to EOF for streams.
+    while (arrData.length && stream.write(arrData[0])) {
+        // If successfully written, remove written one from the arrData.
+        arrData.shift();
+    }
+    if (arrData.length) {
+        stream.once(
+            'drain',
+            () => writeToStream(stream, arrData)
+        );
+    } else {
+        stream.end();
+    }
+}
+
+function entriesHaveGlobalDep(arrEntries, globalName) {
+    return arrEntries.some(({deps, normalizedId}) => {
+        return normalizedId === globalName ||
+            Object.keys(deps)
+            .map(key => deps[key])
+            .some(dep => dep === globalName);
+    });
+}
+
+/**
+ * In case global dependency got mixed into the bundleEntries,
+ * remove those so we can have smaller payload.
+ */
+function removeGlobalDep(bundleEntries) {
+    return bundleEntries.filter(({normalizedId}) => {
+        return !EXPOSE_GLOBAL.has(normalizedId);
+    });
+}
+
+module.exports = function mendelBrowserPack(bundleEntries, browserPackOptions) {
+    const pack = browserpack(
+        Object.assign(
+            {},
+            browserPackOptions,
+            {
+                raw: true, // since we pass Object instead of JSON string
+                hasExports: true, // exposes `require` globally. Required for multi-bundles.
+            }
+        )
+    );
+
+    const globalDepKeys = Array.from(EXPOSE_GLOBAL).map(([key]) => {
+        return entriesHaveGlobalDep(bundleEntries, key) && key;
+    });
+    const hasGlobalDep = globalDepKeys.some(h => h);
+    if (hasGlobalDep) bundleEntries = removeGlobalDep(bundleEntries);
+    bundleEntries = indexedDeps(bundleEntries);
+
+    let prelude = '';
+    let appendix = '';
+
+    if (hasGlobalDep) {
+        prelude = '(function(){';
+        appendix = '})();';
+    }
+
+    globalDepKeys.filter(Boolean).forEach(key => {
+        prelude += EXPOSE_GLOBAL.get(key);
+    });
+
+    const stream = new PaddedStream({appendix, prelude});
+    pack.pipe(stream);
+
+    writeToStream(pack, bundleEntries);
+
+    return stream;
+};

--- a/packages/mendel-browser-pack/package.json
+++ b/packages/mendel-browser-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-browser-pack",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "description": "Mendel internal package for wrapping browser-pack for applying global shims.",
   "main": "index.js",
   "scripts": {

--- a/packages/mendel-browser-pack/package.json
+++ b/packages/mendel-browser-pack/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mendel-browser-pack",
+  "version": "3.0.0",
+  "description": "Mendel internal package for wrapping browser-pack for applying global shims.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Stephan Lee <stephanwlee@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "browser-pack": "^6.0.2"
+  }
+}

--- a/packages/mendel-middleware/index.js
+++ b/packages/mendel-middleware/index.js
@@ -3,7 +3,7 @@
    See the accompanying LICENSE file for terms. */
 
 var pathToRegexp = require('path-to-regexp');
-var bpack = require('browser-pack');
+var mbpack = require('mendel-browser-pack');
 var MendelTrees = require('mendel-core');
 var MendelLoader = require('mendel-loader');
 var debug = require('debug')('mendel:middleware');
@@ -104,19 +104,18 @@ function MendelMiddleware(opts) {
             return next();
         }
 
-        var pack = bpack({raw: true, hasExports: true});
         var decodedResults = trees.findTreeForHash(params.bundle, params.hash);
         if (!decodedResults || decodedResults.error) {
             return bundleError(res, 404, decodedResults && decodedResults.error, params);
         }
 
-        var modules = indexedDeps(decodedResults.deps.filter(Boolean));
+        var modules = decodedResults.deps.filter(Boolean);
 
         if (!modules.length) {
             // Something wrong, modules shouldn't be zero
             return bundleError(res, 500, {
                 code: 'EMPTYBUNDLE',
-                message: 'Tree contents are empty'
+                message: 'Tree contents are empty',
             }, params);
         }
 
@@ -126,115 +125,9 @@ function MendelMiddleware(opts) {
             'Cache-Control': 'public, max-age=31536000',
         });
 
+        var pack = mbpack(modules);
         pack.pipe(res);
-        for (var i = 0; i < modules.length; i++) {
-            pack.write(modules[i]);
-        }
-        pack.end();
     };
-}
-
-/*
-Here is a piece of hard to read JavaScript.
-This compresses the bundle by renaming all dependency indexes from file paths
-to a numbered index.
-
-Here is a sample transformation:
-[
-  {
-    "entry": true,
-    "id": "/User/me/projects/site/src/main.js",
-    "deps": {
-      "./colors.js": "/User/me/projects/site/src/colors.js",
-      "./shared.js": "/User/me/projects/site/src/shared.js"
-    }
-  },
-  {
-    "id": "/User/me/projects/site/src/colors.js",
-    "deps": {
-      "external-lib": false
-    }
-  },
-  {
-    "expose": "shared",
-    "id": "/User/me/projects/site/src/shared.js",
-    "deps": {}
-  }
-]
-
-Should become:
-[
-  {
-    "entry": true,
-    "id": 1,
-    "deps": {
-      "./colors.js": 2,
-      "./shared.js": "shared"
-    }
-  },
-  {
-    "id": 2,
-    "deps": {
-      "external-lib": false
-    }
-  },
-  {
-    "expose": "shared",
-    "id": "shared",
-    "deps": {}
-  }
-]
-
-*/
-
-function indexedDeps(mods) {
-    // the index can't be ever 0 because 0 is false for browserify
-    var newModIndex = [0];
-
-    // indexes are created first, because deps can come unordered
-    mods.forEach(function(mod){
-        if (!mod.expose) newModIndex.push(mod.id);
-    });
-
-    // create a new array of modified modules
-    return mods.map(function(oldMod) {
-        return Object.keys(oldMod).reduce(function(newMod, prop) {
-
-            if (prop === 'deps') { // deps needs to be reindexed
-                newMod.deps = Object.keys(oldMod.deps).reduce(
-                    function(newDeps, name) {
-                        var id = oldMod.deps[name];
-                        var index = newModIndex.indexOf(id);
-                        if (index > -1) {
-                            newDeps[name] = index;
-                        } else {
-                            // deps not indexed are exposed or external
-                            newDeps[name] = id;
-                        }
-                        return newDeps;
-                    },
-                {});
-            }
-
-
-            else if(prop === 'id') { // id needs to be reindexed
-                var index = newModIndex.indexOf(oldMod.id);
-                if (index > -1) {
-                    newMod.id = index;
-                } else {
-                    // unless it is entry or exposed
-                    newMod.id = oldMod.expose || oldMod.id;
-                }
-            }
-
-            else {
-                // for all other props we just copy over
-                newMod[prop] = oldMod[prop];
-            }
-
-            return newMod;
-        }, {});
-    });
 }
 
 /******

--- a/packages/mendel-middleware/package.json
+++ b/packages/mendel-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-middleware",
-  "version": "3.0.4",
+  "version": "3.1.1",
   "description": "Mendel middleware that uses manifests to output multilayer resolution of isomorphic applications.",
   "main": "index.js",
   "scripts": {

--- a/packages/mendel-middleware/package.json
+++ b/packages/mendel-middleware/package.json
@@ -21,8 +21,8 @@
     "url": "https://github.com/yahoo/mendel"
   },
   "dependencies": {
-    "browser-pack": "^6.0.1",
     "debug": "^2.6.3",
+    "mendel-browser-pack": "3.0.0",
     "mendel-core": "^3.0.3",
     "mendel-loader": "^3.0.0",
     "path-to-regexp": "^1.2.1"

--- a/packages/mendel-outlet-browser-pack/package.json
+++ b/packages/mendel-outlet-browser-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendel-outlet-browser-pack",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Mendel outlet for JavaScript bundles using browser-pack.",
   "main": "src/index.js",
   "scripts": {

--- a/packages/mendel-outlet-browser-pack/package.json
+++ b/packages/mendel-outlet-browser-pack/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/yahoo/mendel"
   },
   "dependencies": {
-    "browser-pack": "^6.0.2",
-    "debug": "^2.6.0"
+    "debug": "^2.6.0",
+    "mendel-browser-pack": "3.0.0"
   }
 }

--- a/packages/mendel-outlet-browser-pack/src/index.js
+++ b/packages/mendel-outlet-browser-pack/src/index.js
@@ -31,7 +31,7 @@ module.exports = class BrowserPackOutlet {
                 // If `outfile` exists, output it to appropriate file
                 const outStream = fs.createWriteStream(options.outfile);
                 stream.pipe(outStream);
-                outStream.on('end', resolve);
+                outStream.on('close', resolve);
                 outStream.on('error', reject);
                 stream.on('error', reject);
             } else {

--- a/packages/mendel-outlet-manifest/src/index.js
+++ b/packages/mendel-outlet-manifest/src/index.js
@@ -52,6 +52,7 @@ module.exports = class ManifestOutlet {
 
         const data = {
             id: item.normalizedId,
+            normalizedId: item.normalizedId,
             deps,
             file: item.id,
             variation: item.variation || this.config.baseConfig.dir,

--- a/packages/mendel-pipeline/src/client/outlets.js
+++ b/packages/mendel-pipeline/src/client/outlets.js
@@ -8,7 +8,7 @@ class MendelOutlets {
         this.outlets = options.outlets;
     }
 
-    perform(bundles, variation=this.options.baseConfig.dir) {
+    perform(bundles, variation=[this.options.baseConfig.dir]) {
         const promises = bundles.map(bundle => {
             const outlet = this.outlets.find(outlet => {
                 return outlet.id === bundle.options.outlet;


### PR DESCRIPTION
Factored out the mendel-browser-pack out of mendel-outlet-browser-pack which handles our outlet specific treatment for node globals.

Production should be fixed with this.