### PR TITLE
Allow recycle of existing daemon if running.

### DIFF
--- a/packages/mendel-pipeline/src/cache/network.js
+++ b/packages/mendel-pipeline/src/cache/network.js
@@ -23,9 +23,6 @@ module.exports = {
                 process.exit(1);
             });
             return server;
-        }).catch(err => {
-            setImmediate(() => process.exit(1));
-            throw err;
         });
     },
 

--- a/packages/mendel-pipeline/src/cache/network/unix-socket.js
+++ b/packages/mendel-pipeline/src/cache/network/unix-socket.js
@@ -2,6 +2,7 @@ const BaseNetwork = require('./base-network');
 const net = require('net');
 const fs = require('fs');
 const {resolve} = require('path');
+const chalk = require('chalk');
 
 function patchSocket(socket) {
     const realWrite = net.Socket.prototype.write;
@@ -56,14 +57,15 @@ class UnixSocketNetwork extends BaseNetwork {
         .then(() => fs.unlinkSync(path))
         // If connection was made OR unlink was unsuccessful
         // throw and exit -- cannot recover.
-        .catch(err => {
-            console.error([
-                'Server cannot start when another server is active.\n',
-                'If no server process is active, please remove or kill',
-                    `"${path}" manually.\n`,
-                'This is a symptom of server process exiting preemptively.',
-            ].join(' '));
-            throw err;
+        .catch(() => {
+            console.error(chalk.red([
+                '==================================================',
+                'Server cannot start when another server is active.',
+                'If no server process is active, ',
+                `please remove or kill "${chalk.bold(path)}" manually.`,
+                '==================================================',
+            ].join('\n')));
+            throw new ReferenceError('Other Daemon Active');
         });
     }
 

--- a/packages/mendel-pipeline/src/cache/server.js
+++ b/packages/mendel-pipeline/src/cache/server.js
@@ -28,6 +28,7 @@ class CacheServer extends EventEmitter {
             debug('listening', config.cacheConnection);
             this.emit('ready');
         }).catch(err => {
+            this.emit('error', err);
             debug('Cache server could not come up', err);
         });
     }

--- a/packages/mendel-pipeline/src/main.js
+++ b/packages/mendel-pipeline/src/main.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const MendelPipelineDaemon = require('./daemon');
 const MendelClient = require('./client/build-all');
 
@@ -19,7 +20,17 @@ class Mendel {
 
     run(callback) {
         this.daemon.run(error => {
-            if (error) return callback(error);
+            if (error) {
+                if (error instanceof ReferenceError) {
+                    console.log(chalk.yellow([
+                        'Instance of Mendel daemon may be running.',
+                        'Attemping to recycle...',
+                    ].join('\n')));
+                } else {
+                    console.error('Unknown daemon execution error: ', error);
+                    process.exit(1);
+                }
+            }
             this.client.run(error => {
                 if (error) return callback(error);
                 setImmediate(() => callback());


### PR DESCRIPTION
This allows "npm run build" to work when you have a tab
that has "npm run daemon" running.
You cannot run two daemons though.